### PR TITLE
Create Button Component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2232,8 +2232,8 @@
     },
     "@material-ui/icons": {
       "version": "4.11.2",
-      "resolved": "https://registry.nlark.com/@material-ui/icons/download/@material-ui/icons-4.11.2.tgz",
-      "integrity": "sha1-s6c1MmZRnNdDtkYa6f38sbJetMU=",
+      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.11.2.tgz",
+      "integrity": "sha512-fQNsKX2TxBmqIGJCSi3tGTO/gZ+eJgWmMJkgDiOfyNaunNaxcklJQFaFogYcFl0qFuaEz1qaXYXboa/bUXVSOQ==",
       "requires": {
         "@babel/runtime": "^7.4.4"
       }

--- a/src/App.js
+++ b/src/App.js
@@ -21,6 +21,7 @@ const theme = createMuiTheme({
       dark: '#005E7D',
       main: '#337E92',
       light: '#C2DCE7',
+      lighter: '#F2F6F8',
     },
     pink: {
       dark: '#FC6D78',

--- a/src/components/DissResponse.js
+++ b/src/components/DissResponse.js
@@ -1,9 +1,10 @@
 import React, {useState, useRef, useEffect} from 'react';
-import {formatTime} from '../helper/index';
-import { Box, Grid, Paper, TextField } from '@material-ui/core';
-import {ToggleButton } from '@material-ui/lab';
-import MISkillsSheet from './layout/MISkillsSheet';
 import { makeStyles } from '@material-ui/core/styles';
+import {formatTime} from '../helper/index';
+import { Box, Grid, Paper } from '@material-ui/core';
+import { ToggleButton } from '@material-ui/lab';
+import ColorLibTextField from './layout/ColorLibComponents/ColorLibTextField';
+import MISkillsSheet from './layout/MISkillsSheet';
 
 // firebase hook
 import { usePins } from '../hooks/index';
@@ -14,12 +15,13 @@ import { useUserModeValue } from '../context';
 
 const useStyles = makeStyles((theme) => ({
     root: {
-      '& > *': {
-        margin: theme.spacing(2),
-        width: '45ch',
-      },
+        display: 'flex',
+        '& > *': {
+            margin: theme.spacing(2),
+            width: 'auto',
+        },
     },
-  }));
+}));
 
 const DissResponse = ({curPinIndex}) => {   
     // user mode switcher
@@ -117,11 +119,11 @@ const DissResponse = ({curPinIndex}) => {
             <Paper >
                 <h2>{userMode}</h2>
                 {/* <Button variant="contained" onClick = {() => handleUserModeSwitch()}>userMode switcher</Button> */}
-                <Box m={2} height={700} width = {800} overflow="auto" >
+                <Box m={2} height={700}>
                     <Box fontStyle="italic" fontSize={18}>
                         Pinned at {formatTime(pins.map(pin => pin.pinTime)[curPinIndex])}
                     </Box>
-                    <TextField
+                    <ColorLibTextField
                         id="outlined-secondary"
                         label="Personal Notes..."
                         fullWidth
@@ -138,7 +140,7 @@ const DissResponse = ({curPinIndex}) => {
                         What is your perspective of what happened at this pin? 
                     </Box>
                     <form className={classes.root} noValidate autoComplete="off">
-                    <TextField
+                    <ColorLibTextField
                         id="outlined-secondary"
                         label="caller's perspective"
                         fullWidth
@@ -148,14 +150,14 @@ const DissResponse = ({curPinIndex}) => {
                         margin="normal"                        
                         value = {curPerspectiveInfo1}
                     />
-                    <TextField
+                    <ColorLibTextField
                         id="outlined-secondary"
                         label="callee's perspective"
                         fullWidth
                         variant="outlined"
                         multiline
                         rows={3}
-                        margin="normal"                        
+                        margin="normal"
                         value = {curPerspectiveInfo2}
                     />
                     </form>
@@ -172,17 +174,17 @@ const DissResponse = ({curPinIndex}) => {
                     </form>
                     <MISkillsSheet />
                     <form className={classes.root} noValidate autoComplete="off">
-                        <TextField
+                        <ColorLibTextField
                             id="outlined-secondary"
                             label="caller's MI skill"
                             fullWidth
                             variant="outlined"
                             multiline
                             rows={1}
-                            margin="normal"                        
+                            margin="normal"
                             value = {curSkillInfo1}
                         />
-                        <TextField
+                        <ColorLibTextField
                             id="outlined-secondary"
                             label="callee's MI skill"
                             fullWidth
@@ -197,14 +199,13 @@ const DissResponse = ({curPinIndex}) => {
                     <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" m={1}> 
                         Why was the pinned situation effective or ineffective?
                     </Box>  
-                    <TextField
+                    <ColorLibTextField
                         id="outlined-secondary"
-                        label="Type a response..."
                         fullWidth
                         variant="outlined"
                         multiline
                         rowsMax={2}
-                        margin="normal"                        
+                        margin="normal"
                         // value = {curSkillInfo}
                         // inputRef={skillValueRef}
                         // onChange = {() => handlePinInfo("pinInfos.pinSkill", skillValueRef.current.value)}

--- a/src/components/Notetaking.js
+++ b/src/components/Notetaking.js
@@ -1,7 +1,8 @@
 import React, {useState, useRef, useEffect} from 'react';
 import {formatTime} from '../helper/index';
-import { Box, Grid, Paper, TextField } from '@material-ui/core';
+import { Box, Grid, Paper } from '@material-ui/core';
 import {ToggleButton, ToggleButtonGroup } from '@material-ui/lab';
+import ColorLibTextField from './layout/ColorLibComponents/ColorLibTextField';
 import MISkillsSheet from './layout/MISkillsSheet';
 
 // firebase hook
@@ -110,9 +111,8 @@ const Notetaking = ({curPinIndex}) => {
                     <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" m={2}> 
                         Personal Notes
                     </Box>
-                    <TextField
+                    <ColorLibTextField
                         id="outlined-secondary"
-                        label="Type a response..."
                         fullWidth
                         variant="outlined"
                         multiline
@@ -126,9 +126,8 @@ const Notetaking = ({curPinIndex}) => {
                     <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" m={2}> 
                         What is your perspective of what happened at this pin? 
                     </Box>
-                    <TextField
+                    <ColorLibTextField
                         id="outlined-secondary"
-                        label="Type a response..."
                         fullWidth
                         variant="outlined"
                         multiline
@@ -157,9 +156,8 @@ const Notetaking = ({curPinIndex}) => {
                         </ToggleButtonGroup>
                     </Box>   
                     <MISkillsSheet pinType = {pinType}/>
-                    <TextField
+                    <ColorLibTextField
                         id="outlined-secondary"
-                        label="Type a response..."
                         fullWidth
                         variant="outlined"
                         multiline

--- a/src/components/VideoChatComponent.js
+++ b/src/components/VideoChatComponent.js
@@ -54,14 +54,6 @@ const useStyles = makeStyles((theme) => ({
   '& > * + *': {
     marginLeft: theme.spacing(5),
   },
-  beginDiscussionPrepButton: {
-    backgroundColor: '#DB0000',
-    opacity: '62%',
-    '&:hover': {
-      backgroundColor: '#DB0000',
-      opacity: '100%',
-    }, 
-  },
 }));
 
 function VideoChatComponent(props) {
@@ -553,7 +545,6 @@ function VideoChatComponent(props) {
         <ColorLibCallEndButton
           variant="contained"
           size="medium"
-          className={classes.beginDiscussionPrepButton}
           onClick={() => handleFinishChat()}
           disabled={!isInterviewStarted}
         >

--- a/src/components/VideoChatComponent.js
+++ b/src/components/VideoChatComponent.js
@@ -1,8 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useSelector } from "react-redux";
 import { makeStyles } from '@material-ui/core/styles';
-import ArrowForwardIosIcon from '@material-ui/icons/ArrowForwardIos';
-import CallEndIcon from '@material-ui/icons/CallEnd';
 import MicIcon from "@material-ui/icons/MicNone";
 import MicOffIcon from "@material-ui/icons/MicOffOutlined";
 import VideocamIcon from "@material-ui/icons/VideocamOutlined";
@@ -22,7 +20,7 @@ import DialogContentText from '@material-ui/core/DialogContentText';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import Popper from '@material-ui/core/Popper';
 
-import ColorLibButton from './layout/ColorLibComponents/ColorLibButton';
+import { ColorLibNextButton, ColorLibCallEndButton } from './layout/ColorLibComponents/ColorLibButton';
 
 import {
   toggleAudio,
@@ -520,17 +518,16 @@ function VideoChatComponent(props) {
                     </DialogContentText>
                 </DialogContent>
                 <DialogActions>
-                    <ColorLibButton
-                      variant='contained'
-                      size='medium'
-                      endIcon={<ArrowForwardIosIcon />}
-                      onClick={
-                        () => handleStartChat(setApiKey, setSessionId, setToken, baseURL)
-                      }
-                      autoFocus
-                    >
-                      Join Now
-                    </ColorLibButton>
+                  <ColorLibNextButton
+                    variant='contained'
+                    size='medium'
+                    onClick={
+                      () => handleStartChat(setApiKey, setSessionId, setToken, baseURL)
+                    }
+                    autoFocus
+                  >
+                    Join Now
+                  </ColorLibNextButton>
                 </DialogActions>
             </Dialog>    
       
@@ -553,16 +550,15 @@ function VideoChatComponent(props) {
           </div> 
           </div>
           <div className='actions-btns'>
-        <ColorLibButton
+        <ColorLibCallEndButton
           variant="contained"
           size="medium"
           className={classes.beginDiscussionPrepButton}
-          startIcon={<CallEndIcon />}
           onClick={() => handleFinishChat()}
           disabled={!isInterviewStarted}
         >
           Begin Discussion Prep
-        </ColorLibButton>
+        </ColorLibCallEndButton>
         {props.isArchiveHost ? 
         <Button 
           onClick = {() => handleStartArchive()}

--- a/src/components/VideoChatComponent.js
+++ b/src/components/VideoChatComponent.js
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from "react";
 import { useSelector } from "react-redux";
 import { makeStyles } from '@material-ui/core/styles';
+import ArrowForwardIosIcon from '@material-ui/icons/ArrowForwardIos';
+import CallEndIcon from '@material-ui/icons/CallEnd';
 import MicIcon from "@material-ui/icons/MicNone";
 import MicOffIcon from "@material-ui/icons/MicOffOutlined";
 import VideocamIcon from "@material-ui/icons/VideocamOutlined";
@@ -20,6 +22,7 @@ import DialogContentText from '@material-ui/core/DialogContentText';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import Popper from '@material-ui/core/Popper';
 
+import ColorLibButton from './layout/ColorLibComponents/ColorLibButton';
 
 import {
   toggleAudio,
@@ -52,6 +55,14 @@ const useStyles = makeStyles((theme) => ({
   display: 'flex',
   '& > * + *': {
     marginLeft: theme.spacing(5),
+  },
+  beginDiscussionPrepButton: {
+    backgroundColor: '#DB0000',
+    opacity: '62%',
+    '&:hover': {
+      backgroundColor: '#DB0000',
+      opacity: '100%',
+    }, 
   },
 }));
 
@@ -244,10 +255,10 @@ function VideoChatComponent(props) {
               <Tooltip title="mic on">
                 <Fab size="medium" style={{marginBottom:10, marginRight:10, backgroundColor: '#565656'}}>
                   <Button>
-                  <MicIcon classes={{root: classes.iconRoot}}
-                    onClick={() => onToggleAudio(false)}
-                    className="on-icon">
-                  </MicIcon>
+                    <MicIcon classes={{root: classes.iconRoot}}
+                      onClick={() => onToggleAudio(false)}
+                      className="on-icon">
+                    </MicIcon>
                   </Button>
                 </Fab>
               </Tooltip>
@@ -255,10 +266,10 @@ function VideoChatComponent(props) {
               <Tooltip title="mic off">
                 <Fab size="medium" style={{marginBottom:10, marginRight:10, backgroundColor: '#565656'}}>
                   <Button color="#616161">
-                  <MicOffIcon classes={{root: classes.iconRoot}}
-                    onClick={() => onToggleAudio(true)}
-                    className="off-icon">
-                  </MicOffIcon>
+                    <MicOffIcon classes={{root: classes.iconRoot}}
+                      onClick={() => onToggleAudio(true)}
+                      className="off-icon">
+                    </MicOffIcon>
                   </Button>
                 </Fab>
               </Tooltip>
@@ -267,10 +278,10 @@ function VideoChatComponent(props) {
               <Tooltip title="camera on">
                 <Fab size="medium" color="#36454f" style={{marginBottom:10, marginRight:10, backgroundColor: '#565656'}}>
                   <Button>
-                  <VideocamIcon classes={{root: classes.iconRoot}}
-                    onClick={() => onToggleVideo(false)}
-                    className="on-icon">
-                  </VideocamIcon>
+                    <VideocamIcon classes={{root: classes.iconRoot}}
+                      onClick={() => onToggleVideo(false)}
+                      className="on-icon">
+                    </VideocamIcon>
                   </Button>
                 </Fab>
               </Tooltip>
@@ -278,10 +289,10 @@ function VideoChatComponent(props) {
               <Tooltip title="camera off">
                 <Fab size="medium" color="#36454f" style={{marginBottom:10, marginRight:10, backgroundColor: '#565656'}}>
                   <Button>
-                  <VideocamOffIcon classes={{root: classes.iconRoot}}
-                    onClick={() => onToggleVideo(true)}
-                    className="off-icon">
-                  </VideocamOffIcon>
+                    <VideocamOffIcon classes={{root: classes.iconRoot}}
+                      onClick={() => onToggleVideo(true)}
+                      className="off-icon">
+                    </VideocamOffIcon>
                   </Button>
                 </Fab>
               </Tooltip>
@@ -509,9 +520,17 @@ function VideoChatComponent(props) {
                     </DialogContentText>
                 </DialogContent>
                 <DialogActions>
-                    <Button onClick={() => handleStartChat(setApiKey, setSessionId, setToken, baseURL)} color="primary" autoFocus>
-                        Join Now
-                    </Button>
+                    <ColorLibButton
+                      variant='contained'
+                      size='medium'
+                      endIcon={<ArrowForwardIosIcon />}
+                      onClick={
+                        () => handleStartChat(setApiKey, setSessionId, setToken, baseURL)
+                      }
+                      autoFocus
+                    >
+                      Join Now
+                    </ColorLibButton>
                 </DialogActions>
             </Dialog>    
       
@@ -534,14 +553,16 @@ function VideoChatComponent(props) {
           </div> 
           </div>
           <div className='actions-btns'>
-        <Button
+        <ColorLibButton
+          variant="contained"
+          size="medium"
+          className={classes.beginDiscussionPrepButton}
+          startIcon={<CallEndIcon />}
           onClick={() => handleFinishChat()}
           disabled={!isInterviewStarted}
-          color='secondary'
-          variant="contained"
         >
           Begin Discussion Prep
-        </Button>
+        </ColorLibButton>
         {props.isArchiveHost ? 
         <Button 
           onClick = {() => handleStartArchive()}

--- a/src/components/layout/Collaboration.jsx
+++ b/src/components/layout/Collaboration.jsx
@@ -5,7 +5,8 @@ import AudioReview from '../AudioReview';
 import Transcription from '../Transcription';
 // Others
 import { makeStyles } from '@material-ui/core/styles';
-import { Container, Grid, Button } from '@material-ui/core';
+import { Container, Grid } from '@material-ui/core';
+import ColorLibButton from './ColorLibComponents/ColorLibButton';
 import VideoChatComponent from '../VideoChatComponent';
 import { useSessionValue, useActiveStepValue } from "../../context";
 import { baseURL } from 'constants';
@@ -58,12 +59,14 @@ const Collaboration = () => {
         </Grid>
       </Container>
       <div style={{display: 'flex', alignItems: 'center', justifyContent: 'center'}}>
-            <Button 
-             variant="contained"
-             onClick={handleNext}>
-                Begin Self-Reflection
-            </Button>
-            </div>
+        <ColorLibButton 
+          variant="contained"
+          size="medium"
+          onClick={handleNext}
+        >
+          Begin Self-Reflection
+        </ColorLibButton>
+      </div>
     </div>
   );
 };

--- a/src/components/layout/ColorLibButton.jsx
+++ b/src/components/layout/ColorLibButton.jsx
@@ -1,0 +1,114 @@
+import {withStyles} from '@material-ui/core/styles';
+
+import Button from '@material-ui/core/Button';
+import ArrowBackIosIcon from '@material-ui/icons/ArrowBackIos';
+import ArrowForwardIosIcon from '@material-ui/icons/ArrowForwardIos';
+
+const ColorLibButton = withStyles((theme) => ({
+  root: { /* sizeMedium */ 
+    borderRadius: '35px',
+    fontSize: '20px',
+    fontWeight: '600',
+    lineHeight: '1.5',
+    padding: '6px 39px',
+    textTransform: 'none',
+  },
+  sizeLarge: {
+    fontSize: '25px',
+    fontWeight: '600',
+    lineHeight: '37.5px',
+  },
+  sizeSmall: {
+    fontWeight: '400',
+    lineHeight: 'normal',
+  },
+  contained: {
+    backgroundColor: theme.palette.teal.main,
+    boxShadow: '0px 6px 8px 0px rgb(51 126 146 / 25%)',
+    color: 'white',
+  }, 
+  outlined: {
+    backgroundColor: theme.palette.teal.lighter,
+    borderWidth: '0',
+    boxShadow: 'inset 0px 0px 0px 2PX #337E92',
+    // try to make the border inward
+    color: theme.palette.teal.main,
+  },
+}))(Button);
+
+/* Examples for commonly used buttons */
+export const ColorLibButtonDemo = () => (
+  <div>
+    <div>
+      <font size='+2'><b>Buttons</b></font>
+    </div>
+
+    <br />
+
+    <div>
+      <ColorLibButton variant="contained" size="large">
+        Big Required Button
+      </ColorLibButton>
+      <ColorLibButton variant="contained" size="large" startIcon={<ArrowBackIosIcon />}>
+        Previous
+      </ColorLibButton>
+      <ColorLibButton variant="contained" size="large" endIcon={<ArrowForwardIosIcon />}>
+        Next
+      </ColorLibButton>
+    </div>
+    
+    <br />
+
+    <div>
+      <ColorLibButton variant="outlined" size="large">
+        Big Optional Button
+      </ColorLibButton>
+    </div>
+    
+    <br />
+
+    <div>
+      <ColorLibButton variant="contained" size="medium">
+        Medium Required Button
+      </ColorLibButton>
+      <ColorLibButton variant="contained" size="medium" startIcon={<ArrowBackIosIcon />}>
+        Previous
+      </ColorLibButton>
+      <ColorLibButton variant="contained" size="medium" endIcon={<ArrowForwardIosIcon />}>
+        Next
+      </ColorLibButton>
+    </div>
+    
+    <br />
+
+    <div>
+      <ColorLibButton variant="outlined" size="medium">
+        Medium Optional Button
+      </ColorLibButton>
+    </div>
+    
+    <br />
+
+    <div>
+      <ColorLibButton variant="contained" size="small">
+        Small Required Button
+      </ColorLibButton>
+      <ColorLibButton variant="contained" size="small" startIcon={<ArrowBackIosIcon />}>
+        Previous
+      </ColorLibButton>
+      <ColorLibButton variant="contained" size="small" endIcon={<ArrowForwardIosIcon />}>
+        Next
+      </ColorLibButton>
+    </div>
+    
+    <br />
+
+    <div>
+      <ColorLibButton variant="outlined" size="small">
+        Small Optional Button
+      </ColorLibButton>
+    </div>
+  </div>
+);
+
+export default ColorLibButton;

--- a/src/components/layout/ColorLibComponents/ColorLibButton.jsx
+++ b/src/components/layout/ColorLibComponents/ColorLibButton.jsx
@@ -1,8 +1,9 @@
-import {withStyles} from '@material-ui/core/styles';
+import { makeStyles, withStyles } from '@material-ui/core/styles';
 
 import Button, { ButtonProps } from '@material-ui/core/Button';
 import ArrowBackIosIcon from '@material-ui/icons/ArrowBackIos';
 import ArrowForwardIosIcon from '@material-ui/icons/ArrowForwardIos';
+import CallEndIcon from '@material-ui/icons/CallEnd';
 
 const ColorLibButton = withStyles((theme) => ({
   root: { /* sizeMedium */ 
@@ -36,6 +37,81 @@ const ColorLibButton = withStyles((theme) => ({
   },
 }))(Button);
 
+/* Commony Used Variations */
+export const ColorLibNextButton = (props) => (
+  <ColorLibButton 
+    endIcon={<ArrowForwardIosIcon />}
+    {...props}
+  />
+);
+
+export const ColorLibBackButton = (props) => (
+  <ColorLibButton 
+    startIcon={<ArrowBackIosIcon />}
+    {...props}
+  />
+);
+
+const useSpecialButtonStyles = makeStyles((theme) => ({
+  callEndButton: {
+    backgroundColor: '#DB0000',
+    color: 'white',
+    opacity: '62%',
+    '&:hover': {
+      backgroundColor: '#DB0000',
+      opacity: '100%',
+    },
+  },
+  grayNextButton: {
+    backgroundColor: 'black',
+    color: 'white',
+    opacity: '50%',
+    '&:hover': {
+      backgroundColor: 'black',
+      opacity: '100%',
+    },
+  },
+}));
+
+export const ColorLibCallEndButton = (props) => {
+  const CallEndButton = withStyles({
+    root: {
+      backgroundColor: '#DB0000',
+      color: 'white',
+      opacity: '62%',
+      '&:hover': {
+        backgroundColor: '#DB0000',
+        opacity: '100%',
+      },
+    },
+  })(ColorLibButton);
+  return (
+    <CallEndButton 
+      {...props}
+      startIcon={<CallEndIcon />}
+    />
+  );
+};
+
+export const ColorLibGrayNextButton = (props) => {
+  const GrayNextButton = withStyles({
+    root: {
+      backgroundColor: 'black',
+      color: 'white',
+      opacity: '50%',
+      '&:hover': {
+        backgroundColor: 'black',
+        opacity: '100%',
+      },
+    },
+  })(ColorLibNextButton);
+  return (
+    <GrayNextButton 
+      {...props}
+    />
+  );
+};
+
 /* Examples for commonly used buttons */
 export const ColorLibButtonDemo = () => (
   <div>
@@ -49,12 +125,12 @@ export const ColorLibButtonDemo = () => (
       <ColorLibButton variant="contained" size="large">
         Big Required Button
       </ColorLibButton>
-      <ColorLibButton variant="contained" size="large" startIcon={<ArrowBackIosIcon />}>
+      <ColorLibBackButton variant="contained" size="large">
         Previous
-      </ColorLibButton>
-      <ColorLibButton variant="contained" size="large" endIcon={<ArrowForwardIosIcon />}>
+      </ColorLibBackButton>
+      <ColorLibNextButton variant="contained" size="large">
         Next
-      </ColorLibButton>
+      </ColorLibNextButton>
     </div>
     
     <br />
@@ -71,12 +147,12 @@ export const ColorLibButtonDemo = () => (
       <ColorLibButton variant="contained" size="medium">
         Medium Required Button
       </ColorLibButton>
-      <ColorLibButton variant="contained" size="medium" startIcon={<ArrowBackIosIcon />}>
+      <ColorLibBackButton variant="contained" size="medium">
         Previous
-      </ColorLibButton>
-      <ColorLibButton variant="contained" size="medium" endIcon={<ArrowForwardIosIcon />}>
+      </ColorLibBackButton>
+      <ColorLibNextButton variant="contained" size="medium">
         Next
-      </ColorLibButton>
+      </ColorLibNextButton>
     </div>
     
     <br />
@@ -93,12 +169,12 @@ export const ColorLibButtonDemo = () => (
       <ColorLibButton variant="contained" size="small">
         Small Required Button
       </ColorLibButton>
-      <ColorLibButton variant="contained" size="small" startIcon={<ArrowBackIosIcon />}>
+      <ColorLibBackButton variant="contained" size="small">
         Previous
-      </ColorLibButton>
-      <ColorLibButton variant="contained" size="small" endIcon={<ArrowForwardIosIcon />}>
+      </ColorLibBackButton>
+      <ColorLibNextButton variant="contained" size="small">
         Next
-      </ColorLibButton>
+      </ColorLibNextButton>
     </div>
     
     <br />
@@ -107,6 +183,22 @@ export const ColorLibButtonDemo = () => (
       <ColorLibButton variant="outlined" size="small">
         Small Optional Button
       </ColorLibButton>
+    </div>
+
+    <br />
+
+    <div>
+      <ColorLibCallEndButton>
+        End Call
+      </ColorLibCallEndButton>
+    </div>
+
+    <br />
+
+    <div>
+      <ColorLibGrayNextButton>
+        Gray Next
+      </ColorLibGrayNextButton>
     </div>
   </div>
 );

--- a/src/components/layout/ColorLibComponents/ColorLibButton.jsx
+++ b/src/components/layout/ColorLibComponents/ColorLibButton.jsx
@@ -1,6 +1,6 @@
 import {withStyles} from '@material-ui/core/styles';
 
-import Button from '@material-ui/core/Button';
+import Button, { ButtonProps } from '@material-ui/core/Button';
 import ArrowBackIosIcon from '@material-ui/icons/ArrowBackIos';
 import ArrowForwardIosIcon from '@material-ui/icons/ArrowForwardIos';
 
@@ -11,7 +11,7 @@ const ColorLibButton = withStyles((theme) => ({
     fontWeight: '600',
     lineHeight: '1.5',
     padding: '6px 39px',
-    textTransform: 'none',
+    textTransform: 'none'
   },
   sizeLarge: {
     fontSize: '25px',

--- a/src/components/layout/ColorLibComponents/ColorLibTextField.jsx
+++ b/src/components/layout/ColorLibComponents/ColorLibTextField.jsx
@@ -1,0 +1,41 @@
+import { makeStyles, withStyles } from '@material-ui/core/styles';
+
+import TextField from '@material-ui/core/TextField';
+
+// const ColorLibTextField = withStyles((theme) => ({
+//   root: {
+//     marginTop: '8px',
+//     '&.MuiInputLabel-root': {
+//       color: theme.palette.teal.main,
+//     },
+//   }
+// }))(TextField);
+
+const ColorLibTextField = withStyles((theme) => ({
+  root: {
+    '& .MuiInputLabel-outlined': {
+      color: theme.palette.gray.main,
+      opacity: '60%',
+    },
+    '& .MuiInputBase-input': {
+      color: theme.palette.gray.main,
+    },
+    '& .MuiOutlinedInput-root': {
+      borderRadius: '5px',
+      '& fieldset': {
+        borderColor: theme.palette.teal.light,
+        borderWidth: '1.5px',
+      },
+      '&:hover fieldset': {
+        borderColor: theme.palette.teal.main,
+        borderWidth: '1.5px',
+      },
+      '&.Mui-focused fieldset': {
+        borderColor: theme.palette.teal.main,
+        borderWidth: '1.5px',
+      }
+    }
+  }
+}))(TextField);
+
+export default ColorLibTextField;

--- a/src/components/layout/ColorLibComponents/ColorLibTextField.jsx
+++ b/src/components/layout/ColorLibComponents/ColorLibTextField.jsx
@@ -11,31 +11,40 @@ import TextField from '@material-ui/core/TextField';
 //   }
 // }))(TextField);
 
-const ColorLibTextField = withStyles((theme) => ({
-  root: {
-    '& .MuiInputLabel-outlined': {
-      color: theme.palette.gray.main,
-      opacity: '60%',
-    },
-    '& .MuiInputBase-input': {
-      color: theme.palette.gray.main,
-    },
-    '& .MuiOutlinedInput-root': {
-      borderRadius: '5px',
-      '& fieldset': {
-        borderColor: theme.palette.teal.light,
-        borderWidth: '1.5px',
+const ColorLibTextField = (props) => {
+  const CustomizedTextField = withStyles((theme) => ({
+    root: {
+      '& .MuiInputLabel-outlined': {
+        color: theme.palette.gray.main,
+        opacity: '60%',
       },
-      '&:hover fieldset': {
-        borderColor: theme.palette.teal.main,
-        borderWidth: '1.5px',
+      '& .MuiInputBase-input': {
+        color: theme.palette.gray.main,
       },
-      '&.Mui-focused fieldset': {
-        borderColor: theme.palette.teal.main,
-        borderWidth: '1.5px',
+      '& .MuiOutlinedInput-root': {
+        borderRadius: '5px',
+        '& fieldset': {
+          borderColor: theme.palette.teal.light,
+          borderWidth: '1.5px',
+        },
+        '&:hover fieldset': {
+          borderColor: theme.palette.teal.main,
+          borderWidth: '1.5px',
+        },
+        '&.Mui-focused fieldset': {
+          borderColor: theme.palette.teal.main,
+          borderWidth: '1.5px',
+        }
       }
     }
-  }
-}))(TextField);
+  }))(TextField);
+
+  return (
+    <CustomizedTextField 
+      {...props}
+      label={props.label ?? "Type a response..."}
+    />
+  )
+}
 
 export default ColorLibTextField;

--- a/src/components/layout/DisscussionPrep.jsx
+++ b/src/components/layout/DisscussionPrep.jsx
@@ -5,8 +5,9 @@ import AudioReview from '../AudioReview';
 import Transcription from '../Transcription';
 // Others
 import { makeStyles } from '@material-ui/core/styles';
-import { Container, Grid, Button } from '@material-ui/core';
+import { Container, Grid } from '@material-ui/core';
 
+import ColorLibButton from './ColorLibComponents/ColorLibButton';
 import { useActiveStepValue } from '../../context';
 
 const useStyles = makeStyles((theme) => ({
@@ -52,12 +53,13 @@ const DisscussionPrep = () => {
         </Grid>
       </Container>
       <div style={{display: 'flex', alignItems: 'center', justifyContent: 'center'}}>
-            <Button 
-             variant="contained"
-             onClick={handleNext}>
-                Join Discussion
-            </Button>
-            </div>
+        <ColorLibButton 
+          variant="contained"
+          size="medium"
+          onClick={handleNext}>
+            Join Discussion
+        </ColorLibButton>
+      </div>
     </div>
   );
 };

--- a/src/components/layout/Landing.jsx
+++ b/src/components/layout/Landing.jsx
@@ -1,36 +1,24 @@
 import { makeStyles } from '@material-ui/core/styles';
-import Button from '@material-ui/core/Button';
 import Container from '@material-ui/core/Container';
 import Typography from '@material-ui/core/Typography';
+import ColorLibButton from './ColorLibComponents/ColorLibButton';
 import Navbar from './Navbar';
 
 const useStyles = makeStyles((theme) => ({
   welcome_container: {
-    padding: "50px 68px 50px 68px",
-    textAlign: "center",
+    padding: '50px 68px 50px 68px',
+    textAlign: 'center',
   },
   welcome_intro: {
     color: theme.palette.teal.dark,
-    fontSize: "xx-large",
-    fontWeight: "bold",
+    fontSize: 'xx-large',
+    fontWeight: 'bold',
   },
   welcome_definition: {
     color: theme.palette.gray.main,
-    fontStyle: "italic",
-    padding: "10px 20px 10px 20px",
+    fontStyle: 'italic',
+    padding: '10px 20px 10px 20px',
   },
-  startbutton: {
-    borderRadius: "35px",
-    backgroundColor: theme.palette.teal.main,
-    color: "white",
-    fontSize: "large",
-    padding: "5px 36px 5px 36px",
-    textTransform: "none",
-    '&:hover': {
-      backgroundColor: theme.palette.teal.light,
-      color: theme.palette.gray.dark,
-    }, 
-  }
 }));
 
 const Landing = () => {
@@ -39,16 +27,17 @@ const Landing = () => {
 	return (
 		<section> 
 			<Navbar />
-			<Container className={classes.welcome_container} maxWidth="md">
+			<Container className={classes.welcome_container} maxWidth='md'>
         <Typography className={classes.welcome_intro}>
           Pin-MI is a platform for practicing MI with your peers with the help of pins.
         </Typography>
         <Typography className={classes.welcome_definition}>
           Pins are time marks that you add during your live role-play session to mark parts of conversation that you would like to revisit during a feedback conversation.
         </Typography>
-				<Button className={classes.startbutton} href="/content">
+        <br />
+				<ColorLibButton variant='contained' size='large' href='/content'>
           Let's get started!
-        </Button>
+        </ColorLibButton>
 			</Container>
 		</section>
 	);

--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -3,7 +3,8 @@ import { makeStyles } from '@material-ui/core/styles';
 import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
-import Button from '@material-ui/core/Button';
+import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
+import ColorLibButton from './ColorLibComponents/ColorLibButton';
 
 const useStyles = makeStyles((theme) => ({
   icon: {
@@ -18,7 +19,9 @@ const useStyles = makeStyles((theme) => ({
   },
   navbar_button: {
     color: theme.palette.gray.dark,
-    textTransform: "capitalize",
+    fontSize: "16px",
+    margin: "0px 13px",
+    padding: "6px 17px",
   },
 }));
 
@@ -32,9 +35,25 @@ export default function ButtonAppBar() {
           <Typography variant="h6" className={classes.icon}>
             Pin-MI
           </Typography>
-          {["home", "practice", "review", "message"].map((label) => (
-            <Button className={classes.navbar_button} key={label}>{label}</Button>
+          {["Home", "Practice", "Reivew"].map((label) => (
+            <ColorLibButton 
+              variant="text" 
+              size="small" 
+              key={label} 
+              className={classes.navbar_button}
+            >
+              {label}
+            </ColorLibButton>
           ))}
+          <ColorLibButton 
+            variant="outlined" 
+            size="small" 
+            key="message" 
+            className={classes.navbar_button} 
+            endIcon={<KeyboardArrowDownIcon />}
+          >
+            Message
+          </ColorLibButton>
         </Toolbar>
       </AppBar>
     </div>

--- a/src/components/layout/PracticeSession.jsx
+++ b/src/components/layout/PracticeSession.jsx
@@ -1,12 +1,11 @@
 import { Box } from '@material-ui/core';
-import ArrowForwardIosIcon from '@material-ui/icons/ArrowForwardIos';
 import React, {useState, useEffect} from 'react';
 import Intro from "./PracticeSession/Intro.jsx"
 import Narrative from "./PracticeSession/Narrative.jsx"
 import Session from "./PracticeSession/Session.jsx"
 
 import { useActiveStepValue, useSessionValue } from "../../context";
-import ColorLibButton from './ColorLibComponents/ColorLibButton';
+import ColorLibButton, { ColorLibNextButton } from './ColorLibComponents/ColorLibButton';
 
 
 function getConditionalContent(page) {
@@ -32,9 +31,13 @@ function getConditionalButton(page, setPage, setButton) {
         return (
           <div>
             <Box align='center' m = {2} mb = {20}>
-              <ColorLibButton variant='contained' size='medium' onClick={() => handleButton()} endIcon={<ArrowForwardIosIcon />}>
+              <ColorLibNextButton 
+                variant='contained' 
+                size='medium' 
+                onClick={() => handleButton()}
+              >
                 Review Information on Client
-              </ColorLibButton>
+              </ColorLibNextButton>
             </Box>
           </div>
         );

--- a/src/components/layout/PracticeSession.jsx
+++ b/src/components/layout/PracticeSession.jsx
@@ -1,10 +1,12 @@
-import { Button, Box } from '@material-ui/core';
+import { Box } from '@material-ui/core';
+import ArrowForwardIosIcon from '@material-ui/icons/ArrowForwardIos';
 import React, {useState, useEffect} from 'react';
 import Intro from "./PracticeSession/Intro.jsx"
 import Narrative from "./PracticeSession/Narrative.jsx"
 import Session from "./PracticeSession/Session.jsx"
 
 import { useActiveStepValue, useSessionValue } from "../../context";
+import ColorLibButton from './ColorLibComponents/ColorLibButton';
 
 
 function getConditionalContent(page) {
@@ -14,7 +16,7 @@ function getConditionalContent(page) {
       case 1:
         return <Narrative />;
       case 2:
-        return <Session /> ;
+        return <Session />;
       default:
         return <div>Unknown</div>;
     }
@@ -27,9 +29,25 @@ function getConditionalButton(page, setPage, setButton) {
 }
     switch (page) {
       case 0:
-        return <div><Box align="center" m = {2} mb = {20}> <Button variant="contained" color="primary" onClick={() => handleButton()}>Review Client Information</Button></Box></div>;
+        return (
+          <div>
+            <Box align='center' m = {2} mb = {20}>
+              <ColorLibButton variant='contained' size='medium' onClick={() => handleButton()} endIcon={<ArrowForwardIosIcon />}>
+                Review Information on Client
+              </ColorLibButton>
+            </Box>
+          </div>
+        );
       case 1:
-        return <div><Box align="center" m = {2} mb = {20}> <Button variant="contained" color="primary" onClick={() => handleButton()}>Begin Live Session</Button></Box></div>;
+        return (
+          <div>
+            <Box align='center' m = {2} mb = {20}> 
+              <ColorLibButton variant='contained' size='medium' onClick={() => handleButton()}>
+                Begin Live Session
+              </ColorLibButton>
+            </Box>
+          </div>
+        );
       case 2:
         return ;
       default:

--- a/src/components/layout/Refresher.jsx
+++ b/src/components/layout/Refresher.jsx
@@ -1,8 +1,9 @@
 import React, {useState} from 'react';
-import { Paper, Box, TextField, Grid, Button } from '@material-ui/core';
+import { Paper, Box, TextField, Grid } from '@material-ui/core';
 import {ToggleButton, ToggleButtonGroup } from '@material-ui/lab';
 import { Fragment } from 'react';
 import { useUserModeValue, useActiveStepValue } from '../../context';
+import ColorLibButton from './ColorLibComponents/ColorLibButton';
 
 const Refresher = () => {
 	const {curActiveStep: activeStep, setCurActiveStep: setActiveStep} = useActiveStepValue();
@@ -173,11 +174,9 @@ const Refresher = () => {
 			</div>
       
 			<div style={{display: 'flex', alignItems: 'center', justifyContent: 'center'}}>
-			<Button 
-			 variant="contained"
-			 onClick={handleNext}>
-				Submit
-			</Button>
+        <ColorLibButton variant='outlined' size='medium' onClick={handleNext}>
+          Submit
+        </ColorLibButton>
 			</div>
 			
 		</Fragment>

--- a/src/components/layout/Refresher.jsx
+++ b/src/components/layout/Refresher.jsx
@@ -1,9 +1,10 @@
 import React, {useState} from 'react';
-import { Paper, Box, TextField, Grid } from '@material-ui/core';
+import { Paper, Box, Grid } from '@material-ui/core';
 import {ToggleButton, ToggleButtonGroup } from '@material-ui/lab';
 import { Fragment } from 'react';
 import { useUserModeValue, useActiveStepValue } from '../../context';
 import ColorLibButton from './ColorLibComponents/ColorLibButton';
+import ColorLibTextField from './ColorLibComponents/ColorLibTextField';
 
 const Refresher = () => {
 	const {curActiveStep: activeStep, setCurActiveStep: setActiveStep} = useActiveStepValue();
@@ -111,35 +112,35 @@ const Refresher = () => {
                 Are you doing OK today?                                
               </Box>
               <Box pl = {3.5} width = {900} >
-                <TextField
+                <ColorLibTextField
                     id="outlined-secondary"
                     label="Convert the closed question to open-ended..."
                     fullWidth
                     variant="outlined"
                     multiline
                     rowsMax={2}
-                    margin="normal"                        
+                    margin="normal"       
                 />
               </Box>
               <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" pl={3.5}> 
                 How much do you drink on a typical drinking occasion?                               
               </Box>
               <Box pl = {3.5} width = {900} >
-                <TextField
+                <ColorLibTextField
                     id="outlined-secondary"
                     label="Convert the closed question to open-ended..."
                     fullWidth
                     variant="outlined"
                     multiline
                     rowsMax={2}
-                    margin="normal"                        
+                    margin="normal"
                 />
               </Box>
               <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" pl={3.5}> 
                 I don’t get what we’re supposed to be doing here.                               
               </Box>
               <Box pl = {3.5} width = {900} >
-                <TextField
+                <ColorLibTextField
                   id="outlined-secondary"
                   label="Form a question in response to the client statement..."
                   fullWidth
@@ -153,7 +154,7 @@ const Refresher = () => {
                 I love my kids, but sometimes they push me to the edge, and then I do things I shouldn’t.
               </Box>
               <Box pl = {3.5} width = {900} >
-                <TextField
+                <ColorLibTextField
                     id="outlined-secondary"
                     label="Form a question in response to the client statement..."
                     fullWidth

--- a/src/components/layout/SelfReflection.jsx
+++ b/src/components/layout/SelfReflection.jsx
@@ -1,8 +1,9 @@
 import React, {useState} from 'react';
-import { Paper, Box, TextField, Grid, Button } from '@material-ui/core';
+import { Paper, Box, Grid, Button } from '@material-ui/core';
 import { Fragment } from 'react';
 
 import ColorLibButton from './ColorLibComponents/ColorLibButton';
+import ColorLibTextField from './ColorLibComponents/ColorLibTextField';
 import { useActiveStepValue } from '../../context';
 
 const SelfReflection = () => {
@@ -27,26 +28,28 @@ const SelfReflection = () => {
                                     What do I feel like are my strengths?                              
                                 </Box>
                                 <Box pl = {3.5} width = {900} >
-                                    <TextField
+                                    <ColorLibTextField
                                             id="outlined-secondary"
+                                            label="Type a strength and press Enter to add"
                                             fullWidth
                                             variant="outlined"
                                             multiline
                                             rowsMax={2}
-                                            margin="normal"                        
+                                            margin="normal"
                                     />
                                 </Box>
                                 <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" pl={3.5}> 
-                                    What are some opportunities for growth?                             
+                                    What are some opportunities for growth?
                                 </Box>
                                 <Box pl = {3.5} width = {900} >
-                                    <TextField
+                                    <ColorLibTextField
                                             id="outlined-secondary"
+                                            label="Type and opportunity and press Enter to add"
                                             fullWidth
                                             variant="outlined"
                                             multiline
                                             rowsMax={2}
-                                            margin="normal"                        
+                                            margin="normal"
                                     />
                                 </Box>
                                 <Box mt = {2} fontStyle="normal" fontSize={20} textAlign="center" fontWeight="fontWeightBold" >
@@ -56,7 +59,7 @@ const SelfReflection = () => {
                                     What steps will I take to improve?                              
                                 </Box>
                                 <Box pl = {3.5} width = {900} >
-                                    <TextField
+                                    <ColorLibTextField
                                             id="outlined-secondary"
                                             fullWidth
                                             variant="outlined"
@@ -69,7 +72,7 @@ const SelfReflection = () => {
                                     What obstacles might get in the way, and how will I overcome them?                                
                                 </Box>
                                 <Box pl = {3.5} width = {900} >
-                                    <TextField
+                                    <ColorLibTextField
                                             id="outlined-secondary"
                                             fullWidth
                                             variant="outlined"
@@ -85,7 +88,7 @@ const SelfReflection = () => {
                                     What would I like to add to my clinical practice?                            
                                 </Box>
                                 <Box pl = {3.5} width = {900} >
-                                    <TextField
+                                    <ColorLibTextField
                                             id="outlined-secondary"
                                             fullWidth
                                             variant="outlined"
@@ -98,7 +101,7 @@ const SelfReflection = () => {
                                     What else would I like to keep reflecting on during the next week?                               
                                 </Box>
                                 <Box pl = {3.5} width = {900} >
-                                    <TextField
+                                    <ColorLibTextField
                                             id="outlined-secondary"
                                             fullWidth
                                             variant="outlined"

--- a/src/components/layout/SelfReflection.jsx
+++ b/src/components/layout/SelfReflection.jsx
@@ -2,6 +2,7 @@ import React, {useState} from 'react';
 import { Paper, Box, TextField, Grid, Button } from '@material-ui/core';
 import { Fragment } from 'react';
 
+import ColorLibButton from './ColorLibComponents/ColorLibButton';
 import { useActiveStepValue } from '../../context';
 
 const SelfReflection = () => {
@@ -115,11 +116,13 @@ const SelfReflection = () => {
 
             </div>
             <div style={{display: 'flex', alignItems: 'center', justifyContent: 'center'}}>
-            <Button 
-             variant="contained"
-             onClick={handleNext}>
+            <ColorLibButton 
+                variant="contained"
+                size="medium"
+                onClick={handleNext}
+            >
                 Finish Self-Reflection
-            </Button>
+            </ColorLibButton>
             </div>
         </Fragment>
     );

--- a/src/components/layout/Steppers.jsx
+++ b/src/components/layout/Steppers.jsx
@@ -90,6 +90,7 @@ const ColorLibLabel = withStyles((theme) => ({
 			fontSize: '20px',
 			fontWeight: 'bold',
 			marginTop: '-84px !important',
+			opacity: '100%',
 			whiteSpace: 'nowrap',
 		},
 		'& .MuiStepLabel-completed': {
@@ -99,6 +100,7 @@ const ColorLibLabel = withStyles((theme) => ({
 	label: {
 		color: theme.palette.teal.main,
 		marginTop: '-80px !important',
+		opacity: '70%',
 	},
 }))(StepLabel);
 

--- a/src/components/layout/Steppers.jsx
+++ b/src/components/layout/Steppers.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import {Step, StepConnector, Stepper, StepLabel} from '@material-ui/core';


### PR DESCRIPTION
### Description
This update creates a customized Button component according to the Figma design. Here is a comparison between the customized buttons (left) and their Figma design (right).
<img width="1149" alt="Button comparison" src="https://user-images.githubusercontent.com/55717622/131397535-63a53459-f1ed-435d-bff7-481aa1b1b72c.png">
For how to use these buttons, refer to the `<ColorLibButtonDemo />` component in `ColorLibComponents/ColorLibButton`.

### Changes
- Created a `ColorLibComponents` folder to store the customized components. 
- Created the `ColorLibButton` component.
- Updated the existing pages to use the Button Component.

### Test Plan
Manually tested.

https://user-images.githubusercontent.com/55717622/131409026-46ca37df-3ca8-4e21-8561-cb91d6133af2.mov

