### PR TITLE
Format Reflection Questions; ColorLibPaper Component; General Font formatting

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="pin.svg" />
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Poppins" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta

--- a/src/App.js
+++ b/src/App.js
@@ -36,6 +36,9 @@ const theme = createMuiTheme({
       light: '#DDEEF9',
     },
   },
+  typography: {
+    fontFamily: "'Poppins', sans-serif",
+  }
 });
 
 const App = () => {

--- a/src/components/layout/ColorLibComponents/ColorLibPaper.jsx
+++ b/src/components/layout/ColorLibComponents/ColorLibPaper.jsx
@@ -1,0 +1,15 @@
+import { makeStyles, withStyles } from '@material-ui/core/styles';
+
+import Paper from '@material-ui/core/Paper';
+
+const ColorLibPaper = withStyles((theme) => ({
+  root: {
+    backgroundColor: theme.palette.teal.lighter,
+    boxShadow: 'none',
+    padding: '50px 80px'
+  },
+  rounded: {
+    borderRadius: '30px',
+  }
+}))(Paper);
+export default ColorLibPaper;

--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -35,7 +35,6 @@ export default function ButtonAppBar() {
           <Typography variant="h6" className={classes.icon}>
             Pin-MI
           </Typography>
-<<<<<<< HEAD
           <ColorLibButton 
             variant="text" 
             size="small"
@@ -45,9 +44,6 @@ export default function ButtonAppBar() {
             Home
           </ColorLibButton>
           {["Practice", "Reivew"].map((label) => (
-=======
-          {["Home", "Practice", "Review"].map((label) => (
->>>>>>> UserTesting
             <ColorLibButton 
               variant="text" 
               size="small" 

--- a/src/components/layout/SelfReflection.jsx
+++ b/src/components/layout/SelfReflection.jsx
@@ -1,112 +1,160 @@
-import { Box, Container } from '@material-ui/core';
-import { Fragment } from 'react';
+import { Box, Container, Paper, Typography } from '@material-ui/core';
+import { useState } from 'react';
 
-import ColorLibButton from './ColorLibComponents/ColorLibButton';
+import ColorLibButton, { ColorLibNextButton, ColorLibBackButton } from './ColorLibComponents/ColorLibButton';
 import ColorLibTextField from './ColorLibComponents/ColorLibTextField';
-import { useActiveStepValue } from '../../context';
 
-const SelfReflection = () => {
-    const {curActiveStep: activeStep, setCurActiveStep: setActiveStep} = useActiveStepValue();
-    
-    return (
-        <Fragment>
-            <div style={{display: 'flex', alignItems: 'center', justifyContent: 'center',}}>
-                <Container maxWidth="md">
-                    <Box fontStyle="normal" fontSize={25} textAlign="center" fontWeight="fontWeightBold" >
-                        Reflect on how the session went and how you felt.
-                    </Box>
-                    <Box mt = {2} fontStyle="normal" fontSize={20} textAlign="center" fontWeight="fontWeightBold" >
-                        Based on today’s session
-                    </Box>
-                    <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" pl={3.5}> 
-                        What do I feel like are my strengths?                              
-                    </Box>
-                    <Box pl = {3.5} width = {900} >
-                        <ColorLibTextField
-                                id="outlined-secondary"
-                                label="Type a strength and press Enter to add"
-                                fullWidth
-                                variant="outlined"
-                                multiline
-                                rowsMax={2}
-                                margin="normal"
-                        />
-                    </Box>
-                    <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" pl={3.5}> 
-                        What are some opportunities for growth?
-                    </Box>
-                    <Box pl = {3.5} width = {900} >
-                        <ColorLibTextField
-                                id="outlined-secondary"
-                                label="Type and opportunity and press Enter to add"
-                                fullWidth
-                                variant="outlined"
-                                multiline
-                                rowsMax={2}
-                                margin="normal"
-                        />
-                    </Box>
-                    <Box mt = {2} fontStyle="normal" fontSize={20} textAlign="center" fontWeight="fontWeightBold" >
-                        Make a plan
-                    </Box>
-                    <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" pl={3.5}> 
-                        What steps will I take to improve?                              
-                    </Box>
-                    <Box pl = {3.5} width = {900} >
-                        <ColorLibTextField
-                                id="outlined-secondary"
-                                fullWidth
-                                variant="outlined"
-                                multiline
-                                rowsMax={2}
-                                margin="normal"                        
-                        />
-                    </Box>
-                    <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" pl={3.5}> 
-                        What obstacles might get in the way, and how will I overcome them?                                
-                    </Box>
-                    <Box pl = {3.5} width = {900} >
-                        <ColorLibTextField
-                                id="outlined-secondary"
-                                fullWidth
-                                variant="outlined"
-                                multiline
-                                rowsMax={2}
-                                margin="normal"                        
-                        />
-                    </Box>
-                    <Box mt = {2} fontStyle="normal" fontSize={20} textAlign="center" fontWeight="fontWeightBold" >
-                        Prepare for change
-                    </Box>
-                    <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" pl={3.5}> 
-                        What would I like to add to my clinical practice?                            
-                    </Box>
-                    <Box pl = {3.5} width = {900} >
-                        <ColorLibTextField
-                                id="outlined-secondary"
-                                fullWidth
-                                variant="outlined"
-                                multiline
-                                rowsMax={2}
-                                margin="normal"                        
-                        />
-                    </Box>
-                    <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" pl={3.5}> 
-                        What else would I like to keep reflecting on during the next week?                               
-                    </Box>
-                    <Box pl = {3.5} width = {900} >
-                        <ColorLibTextField
-                                id="outlined-secondary"
-                                fullWidth
-                                variant="outlined"
-                                multiline
-                                rowsMax={2}
-                                margin="normal"                        
-                        />
-                    </Box>
-                </Container>
+const getPageTitle = (page) => {
+    switch(page) {
+        case 0: return "Based on today’s session";
+        case 1: return "Make a plan";
+        case 2: return "Prepare for change";
+        default: return "";
+    }
+}
+
+const getPageContent = (page) => {
+    switch(page) {
+        case 0: return (
+            <div>
+                <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" pl={3.5}> 
+                    What do I feel like are my strengths?                              
+                </Box>
+                <Box pl = {3.5}>
+                    <ColorLibTextField
+                            id="outlined-secondary"
+                            label="Type a strength and press Enter to add"
+                            fullWidth
+                            variant="outlined"
+                            multiline
+                            rowsMax={2}
+                            margin="normal"
+                    />
+                </Box>
+                <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" pl={3.5}> 
+                    What are some opportunities for growth?
+                </Box>
+                <Box pl = {3.5}>
+                    <ColorLibTextField
+                            id="outlined-secondary"
+                            label="Type and opportunity and press Enter to add"
+                            fullWidth
+                            variant="outlined"
+                            multiline
+                            rowsMax={2}
+                            margin="normal"
+                    />
+                </Box>
             </div>
-            <div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '50px 0px'}}>
+        );
+        case 1: return (
+            <div>
+                <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" pl={3.5}> 
+                    What steps will I take to improve?
+                </Box>
+                <Box pl = {3.5} >
+                    <ColorLibTextField
+                            id="outlined-secondary"
+                            fullWidth
+                            variant="outlined"
+                            multiline
+                            rowsMax={2}
+                            margin="normal"
+                    />
+                </Box>
+                <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" pl={3.5}> 
+                    What obstacles might get in the way, and how will I overcome them?
+                </Box>
+                <Box pl = {3.5}>
+                    <ColorLibTextField
+                            id="outlined-secondary"
+                            fullWidth
+                            variant="outlined"
+                            multiline
+                            rowsMax={2}
+                            margin="normal"
+                    />
+                </Box>
+            </div>
+        );
+        case 2: return (
+            <div>
+                <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" pl={3.5}> 
+                    What would I like to add to my clinical practice?
+                </Box>
+                <Box pl = {3.5}>
+                    <ColorLibTextField
+                        id="outlined-secondary"
+                        fullWidth
+                        variant="outlined"
+                        multiline
+                        rowsMax={2}
+                        margin="normal"
+                    />
+                </Box>
+                <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" pl={3.5}> 
+                    What else would I like to keep reflecting on during the next week?
+                </Box>
+                <Box pl = {3.5}>
+                    <ColorLibTextField
+                            id="outlined-secondary"
+                            fullWidth
+                            variant="outlined"
+                            multiline
+                            rowsMax={2}
+                            margin="normal"
+                    />
+                </Box>
+            </div>
+        )
+        default: return <div />;
+    }
+}
+
+const getPageButtons = (page, setPage) => {
+    const handleNext = () => {
+        setPage(page+1);
+    }
+    const handleBack = () => {
+        setPage(page-1);
+    }
+    switch(page) {
+        case 0: return (
+            <ColorLibNextButton 
+                variant="contained" 
+                size="medium" 
+                onClick={handleNext}
+            >
+                Next
+            </ColorLibNextButton>
+        );
+        case 1: return (
+            <div>
+                <ColorLibBackButton 
+                    variant="outlined" 
+                    size="medium"
+                    onClick={handleBack}
+                >
+                    Back
+                </ColorLibBackButton>
+                <ColorLibNextButton 
+                    variant="contained" 
+                    size="medium" 
+                    onClick={handleNext}
+                >
+                    Next
+                </ColorLibNextButton>
+            </div>
+        );
+        case 2: return (
+            <div>
+                <ColorLibBackButton 
+                    variant="outlined" 
+                    size="medium"
+                    onClick={handleBack}
+                >
+                    Back
+                </ColorLibBackButton>
                 <ColorLibButton 
                     variant="contained"
                     size="medium"
@@ -115,7 +163,27 @@ const SelfReflection = () => {
                     Finish Self-Reflection
                 </ColorLibButton>
             </div>
-        </Fragment>
+        );
+        default: return <div />;
+    }
+}
+
+const SelfReflection = () => {
+    const [page, setPage] = useState(0);
+
+    return (
+        <Container maxWidth = 'md'>
+            <Typography variant="h5">
+                Reflect on how the session went and how you felt.
+            </Typography>
+            <Paper style={{backgroundColor: 'lightgrey', padding: '10px'}}>
+                <Typography variant="h6">
+                    {getPageTitle(page)}
+                </Typography>  
+                {getPageContent(page)}
+                {getPageButtons(page, setPage)}
+            </Paper>
+        </Container>
     );
 }
  

--- a/src/components/layout/SelfReflection.jsx
+++ b/src/components/layout/SelfReflection.jsx
@@ -1,8 +1,24 @@
-import { Box, Container, Paper, Typography } from '@material-ui/core';
+import { Box, Container, Typography } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
 import { useState } from 'react';
 
 import ColorLibButton, { ColorLibNextButton, ColorLibBackButton } from './ColorLibComponents/ColorLibButton';
 import ColorLibTextField from './ColorLibComponents/ColorLibTextField';
+import ColorLibPaper from './ColorLibComponents/ColorLibPaper';
+
+const useStyles = makeStyles((theme) => ({
+    title: {
+        fontSize: '25px',
+        fontWeight: '600',
+    },
+    page: {
+        margin: '24px 0px',
+    },
+    pageTitle: {
+        fontSize: '20px',
+        fontWeight: '600',
+    },
+}));
 
 const getPageTitle = (page) => {
     switch(page) {
@@ -17,10 +33,10 @@ const getPageContent = (page) => {
     switch(page) {
         case 0: return (
             <div>
-                <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" pl={3.5}> 
+                <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" > 
                     What do I feel like are my strengths?                              
                 </Box>
-                <Box pl = {3.5}>
+                <Box>
                     <ColorLibTextField
                             id="outlined-secondary"
                             label="Type a strength and press Enter to add"
@@ -31,10 +47,10 @@ const getPageContent = (page) => {
                             margin="normal"
                     />
                 </Box>
-                <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" pl={3.5}> 
+                <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" > 
                     What are some opportunities for growth?
                 </Box>
-                <Box pl = {3.5}>
+                <Box>
                     <ColorLibTextField
                             id="outlined-secondary"
                             label="Type and opportunity and press Enter to add"
@@ -49,10 +65,10 @@ const getPageContent = (page) => {
         );
         case 1: return (
             <div>
-                <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" pl={3.5}> 
+                <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" > 
                     What steps will I take to improve?
                 </Box>
-                <Box pl = {3.5} >
+                <Box>
                     <ColorLibTextField
                             id="outlined-secondary"
                             fullWidth
@@ -62,10 +78,10 @@ const getPageContent = (page) => {
                             margin="normal"
                     />
                 </Box>
-                <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" pl={3.5}> 
+                <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" > 
                     What obstacles might get in the way, and how will I overcome them?
                 </Box>
-                <Box pl = {3.5}>
+                <Box>
                     <ColorLibTextField
                             id="outlined-secondary"
                             fullWidth
@@ -79,10 +95,10 @@ const getPageContent = (page) => {
         );
         case 2: return (
             <div>
-                <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" pl={3.5}> 
+                <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" > 
                     What would I like to add to my clinical practice?
                 </Box>
-                <Box pl = {3.5}>
+                <Box>
                     <ColorLibTextField
                         id="outlined-secondary"
                         fullWidth
@@ -92,10 +108,10 @@ const getPageContent = (page) => {
                         margin="normal"
                     />
                 </Box>
-                <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" pl={3.5}> 
+                <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" > 
                     What else would I like to keep reflecting on during the next week?
                 </Box>
-                <Box pl = {3.5}>
+                <Box>
                     <ColorLibTextField
                             id="outlined-secondary"
                             fullWidth
@@ -170,19 +186,29 @@ const getPageButtons = (page, setPage) => {
 
 const SelfReflection = () => {
     const [page, setPage] = useState(0);
+    const classes = useStyles();
 
     return (
         <Container maxWidth = 'md'>
-            <Typography variant="h5">
+            <Typography className={classes.title}>
                 Reflect on how the session went and how you felt.
             </Typography>
-            <Paper style={{backgroundColor: 'lightgrey', padding: '10px'}}>
-                <Typography variant="h6">
+            <ColorLibPaper className={classes.page}>
+                <Typography className={classes.pageTitle}>
                     {getPageTitle(page)}
                 </Typography>  
                 {getPageContent(page)}
-                {getPageButtons(page, setPage)}
-            </Paper>
+                <div 
+                    style={{
+                        display: 'flex', 
+                        alignItems: 'center', 
+                        justifyContent: 'center', 
+                        margin: '20px 0 0 0'
+                    }}
+                >
+                    {getPageButtons(page, setPage)}
+                </div>
+            </ColorLibPaper>
         </Container>
     );
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,4 +3,5 @@ import { render } from "react-dom";
 import App from './App';
 
 document.body.style.margin = 0;
+
 render(<App />, document.getElementById("root"));


### PR DESCRIPTION
### Description / Changes
- Formatted Reflection Questions
    - Questions are now on different pages like that on Figma
    - Styles are refined to match with Figma
- Added ColorLibPaper component to replace the material-ui default paper component.
- Updated the default font of the website to Poppins.

Related Jira issue: https://mi-summer-project.atlassian.net/browse/MFP-4

Reflection Page demo: 

https://user-images.githubusercontent.com/55717622/133316686-3767bb0d-d11f-40ad-af7b-987c29fe08d7.mov

### Future TODOs
- Set the background color of text fields to white (instead of transparent).
- Add font family Karla to the theme, so that all body texts use Karla instead of Poppins.