### PR TITLE
Refresher Page Update; Style Theme Typography; ColorLibToggleButton Component

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <link rel="icon" href="pin.svg" />
     <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Poppins" />
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Karla" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta

--- a/src/App.js
+++ b/src/App.js
@@ -66,6 +66,20 @@ const theme = createMuiTheme({
       fontWeight: 600,
       lineHeight: '30px',
     },
+    subtitle1: {
+      fontFamily: 'Karla',
+      fontSize: '20px',
+      fontWeight: 700,
+      lineHeight: '23.38px',
+      letterSpacing: '-0.015em',
+    },
+    subtitle2: {
+      fontFamily: 'Karla',
+      fontSize: '16px',
+      fontWeight: 700,
+      lineHeight: '18.7px',
+      letterSpacing: '-0.02em',
+    },
     body1: {
       fontFamily: 'Karla',
       fontSize: '20px',

--- a/src/App.js
+++ b/src/App.js
@@ -37,7 +37,49 @@ const theme = createMuiTheme({
     },
   },
   typography: {
-    fontFamily: "'Poppins', sans-serif",
+    fontFamily: [
+      'Poppins', 
+      'Karla',
+      'sans-serif'
+    ].join(','),
+    h1: {
+      fontFamily: 'Poppins',
+      fontSize: '35px',
+      fontWeight: 700,
+      lineHeight: '52.5px',
+    },
+    h2: {
+      fontFamily: 'Poppins',
+      fontSize: '25px',
+      fontWeight: 600,
+      lineHeight: '37.5px',
+    },
+    h3: {
+      fontFamily: 'Poppins',
+      fontSize: '20px',
+      fontWeight: 400,
+      lineHeight: '30px',
+    },
+    h4: {
+      fontFamily: 'Poppins',
+      fontSize: '20px',
+      fontWeight: 600,
+      lineHeight: '30px',
+    },
+    body1: {
+      fontFamily: 'Karla',
+      fontSize: '20px',
+      fontWeight: 400,
+      lineHeight: '23.38px',
+      letterSpacing: '-0.015em',
+    },
+    body2: {
+      fontFamily: 'Karla',
+      fontSize: '16px',
+      fontWeight: 400,
+      lineHeight: '18.7px',
+      letterSpacing: '-0.02em',
+    }
   }
 });
 

--- a/src/components/layout/ColorLibComponents/ColorLibButton.jsx
+++ b/src/components/layout/ColorLibComponents/ColorLibButton.jsx
@@ -52,27 +52,6 @@ export const ColorLibBackButton = (props) => (
   />
 );
 
-const useSpecialButtonStyles = makeStyles((theme) => ({
-  callEndButton: {
-    backgroundColor: '#DB0000',
-    color: 'white',
-    opacity: '62%',
-    '&:hover': {
-      backgroundColor: '#DB0000',
-      opacity: '100%',
-    },
-  },
-  grayNextButton: {
-    backgroundColor: 'black',
-    color: 'white',
-    opacity: '50%',
-    '&:hover': {
-      backgroundColor: 'black',
-      opacity: '100%',
-    },
-  },
-}));
-
 export const ColorLibCallEndButton = (props) => {
   const CallEndButton = withStyles({
     root: {

--- a/src/components/layout/ColorLibComponents/ColorLibPaper.jsx
+++ b/src/components/layout/ColorLibComponents/ColorLibPaper.jsx
@@ -16,7 +16,7 @@ const ColorLibPaper = withStyles((theme) => ({
     // For Refresher Page final answer preview
     borderRadius: '10px',
     boxShadow: '0px 0px 9px rgba(51, 126, 146, 0.15)',
-    padding: '6px 14px',
+    padding: '10px 20px',
   },
 }))(Paper);
 

--- a/src/components/layout/ColorLibComponents/ColorLibPaper.jsx
+++ b/src/components/layout/ColorLibComponents/ColorLibPaper.jsx
@@ -4,12 +4,20 @@ import Paper from '@material-ui/core/Paper';
 
 const ColorLibPaper = withStyles((theme) => ({
   root: {
+  },
+  elevation0: {
+    // For Self Reflection Page
     backgroundColor: theme.palette.teal.lighter,
+    borderRadius: '30px',
     boxShadow: 'none',
     padding: '50px 80px',
   },
-  rounded: {
-    borderRadius: '30px',
-  }
+  elevation9: {
+    // For Refresher Page final answer preview
+    borderRadius: '10px',
+    boxShadow: '0px 0px 9px rgba(51, 126, 146, 0.15)',
+    padding: '6px 14px',
+  },
 }))(Paper);
+
 export default ColorLibPaper;

--- a/src/components/layout/ColorLibComponents/ColorLibPaper.jsx
+++ b/src/components/layout/ColorLibComponents/ColorLibPaper.jsx
@@ -6,7 +6,7 @@ const ColorLibPaper = withStyles((theme) => ({
   root: {
     backgroundColor: theme.palette.teal.lighter,
     boxShadow: 'none',
-    padding: '50px 80px'
+    padding: '50px 80px',
   },
   rounded: {
     borderRadius: '30px',

--- a/src/components/layout/ColorLibComponents/ColorLibToggleButton.jsx
+++ b/src/components/layout/ColorLibComponents/ColorLibToggleButton.jsx
@@ -1,0 +1,44 @@
+import { makeStyles, withStyles } from '@material-ui/core/styles';
+
+import ToggleButton from '@material-ui/lab/ToggleButton';
+import ToggleButtonGroup from '@material-ui/lab/ToggleButtonGroup';
+
+const ColorLibToggleButton = withStyles((theme) => ({
+  root: { /* sizeMedium */ 
+    backgroundColor: theme.palette.teal.lighter,
+    borderRadius: '35px',
+    border: '2px solid !important',
+    borderColor: theme.palette.teal.main + '!important',
+    color: theme.palette.gray.dark,
+    fontSize: '20px',
+    fontWeight: '600',
+    lineHeight: '1.5',
+    padding: '10px 27px',
+    textTransform: 'none',
+  },
+  sizeLarge: {
+    fontSize: '25px',
+    fontWeight: '600',
+    lineHeight: '37.5px',
+  },
+  sizeSmall: {
+    fontWeight: '400',
+    lineHeight: '22px',
+  },
+  selected: {
+    backgroundColor: theme.palette.teal.light + '!important',
+    borderWidth: '4px !important',
+    color: theme.palette.gray.dark + '!important',
+  },
+}))(ToggleButton);
+
+export default ColorLibToggleButton;
+
+export const ColorLibToggleButtonGroup = withStyles((theme) => ({
+  groupedHorizontal: { 
+    borderRadius: '35px !important',
+    '&:not(:first-child)': {
+      marginLeft: '15px',
+    },
+  },
+}))(ToggleButtonGroup);

--- a/src/components/layout/ColorLibComponents/ColorLibToggleButton.jsx
+++ b/src/components/layout/ColorLibComponents/ColorLibToggleButton.jsx
@@ -13,7 +13,7 @@ const ColorLibToggleButton = withStyles((theme) => ({
     fontSize: '20px',
     fontWeight: '600',
     lineHeight: '1.5',
-    padding: '10px 27px',
+    padding: '6px 27px',
     textTransform: 'none',
   },
   sizeLarge: {

--- a/src/components/layout/Completion.jsx
+++ b/src/components/layout/Completion.jsx
@@ -46,13 +46,10 @@ const useStyles = makeStyles((theme) => ({
     },
     innerText_title: {
         color: 'white',
-        fontSize: 'xx-large',
-        fontWeight: 'bold',
         marginTop: '30px',
     },
     innerText_content: {
         color: 'white',
-        fontWeight: 'bold',
         marginBottom: '20px',
     },
     rescheduleButton: {
@@ -78,10 +75,10 @@ const Completion = () => {
                         </Icon>
                     </Fab>
                     <br />
-                    <Typography className={classes.innerText_title}>
+                    <Typography variant='h1' className={classes.innerText_title}>
                         Congratulations!
                     </Typography>
-                    <Typography className={classes.innerText_content}>
+                    <Typography variant='h2' className={classes.innerText_content}>
                         You have successfully finished today’s session in Pin-MI.
                     </Typography>
                     <br />

--- a/src/components/layout/Landing.jsx
+++ b/src/components/layout/Landing.jsx
@@ -13,8 +13,6 @@ const useStyles = makeStyles((theme) => ({
   },
   welcome_intro: {
     color: theme.palette.teal.dark,
-    fontSize: 'xx-large',
-    fontWeight: 'bold',
   },
   welcome_definition: {
     color: theme.palette.gray.main,
@@ -30,10 +28,10 @@ const Landing = () => {
 		<section> 
 			<Navbar />
 			<Container className={classes.welcome_container} maxWidth='md'>
-        <Typography className={classes.welcome_intro}>
+        <Typography variant='h1' className={classes.welcome_intro}>
           Pin-MI is a platform for practicing MI with your peers with the help of pins.
         </Typography>
-        <Typography className={classes.welcome_definition}>
+        <Typography variant='h3' className={classes.welcome_definition}>
           Pins are time marks that you add during your live role-play session to mark parts of conversation that you would like to revisit during a feedback conversation.
         </Typography>
         <br />

--- a/src/components/layout/Refresher.jsx
+++ b/src/components/layout/Refresher.jsx
@@ -9,7 +9,8 @@ import ColorLibPaper from './ColorLibComponents/ColorLibPaper';
 import Typography from '@material-ui/core/Typography';
 
 const Refresher = () => {
-	const {curActiveStep: activeStep, setCurActiveStep: setActiveStep} = useActiveStepValue();
+  const {curActiveStep: activeStep, setCurActiveStep: setActiveStep} = useActiveStepValue();
+  const [submitted, setSubmitted] = useState(false);
 	const [question1Ans, setQuestion1Ans] = useState('');
 	const [question2Ans, setQuestion2Ans] = useState('');
 
@@ -21,13 +22,13 @@ const Refresher = () => {
 		}
 	};
 
-	const handleQestion1 = (event, newAns) => {
+	const handleQuestion1 = (event, newAns) => {
 	  if (newAns !== null) {
 		setQuestion1Ans(newAns);
 	  }
 	};
 
-	const handleQestion2 = (event, newAns) => {
+	const handleQuestion2 = (event, newAns) => {
 		if (newAns !== null) {
 		  setQuestion2Ans(newAns);
 		}
@@ -35,7 +36,139 @@ const Refresher = () => {
 
 	const handleNext = () => {
 		setActiveStep((prevActiveStep) => prevActiveStep + 1);
-	};
+  };
+
+  const handleSubmit = () => {
+    setSubmitted(true);
+  }
+  
+  /* TODO: The 'submittedResponse's are just placeholders for now.
+   * After the database is set up, then should be replaced with what was sent to the database. */
+  const openEndedQuestions = [
+    {
+      question: "Are you doing OK today?",
+      description: "Convert the closed question to open-ended...",
+      submittedResponse: "How is your day going?",
+      sampleResponse: "What has been good in your day so far?",
+    }, 
+    {
+      question: "How much do you drink on a typical drinking occasion?",
+      description: "Convert the closed question to open-ended...",
+      submittedResponse: "Do you drink occasionally?",
+      sampleResponse: "What's a typical drinking occasion like for you?",
+    },
+    {
+      question: "I don't get what we're supposed to be doing here.",
+      description: "Form a question in response to the client statement...",
+      submittedResponse: "Do you understand why I am asking you these questions?",
+      sampleResponse: "What's your understanding of why you are here?",
+    },
+    {
+      question: "I love my kids, but sometimes they push me to the edge, and then I do things I shouldn't.",
+      description: "Form a question in response to the client statement...",
+      submittedResponse: "Would you like me to help you with some coping skills?",
+      sampleResponse: "What are the feelings like after one of these episodes when you've felt pushed and then reacted in a way you didn't like?",
+    }
+  ]
+
+  const getOpenEndQuestionSet = (question, submitted) => {
+    let response = <div />;
+    if (!submitted) {
+      response = (
+        <ColorLibTextField
+          id="outlined-secondary"
+          label={question.description}
+          fullWidth
+          variant="outlined"
+          multiline
+          rowsMax={2}
+           margin="normal"
+        />
+      );
+    } else {
+      response = (
+        <Grid 
+          container 
+          direction="row"
+          justifyContent="center"
+          style={{
+            alignItems: 'stretch',
+            margin: '16px 0px 26px 0px',
+          }}
+        >
+          <Grid item xs={6}>
+            <ColorLibPaper 
+              elevation={9} 
+              style={{
+                height: 'calc(100% - 16px)',
+                marginRight: '17px',
+              }}
+            >
+              <Typography variant="subtitle2">
+                Your Response
+              </Typography>
+              <Typography variant="body2">
+                {question.submittedResponse}
+              </Typography>
+            </ColorLibPaper>
+          </Grid>
+          <Grid item xs={6}>
+            <ColorLibPaper 
+              elevation={9} 
+              style={{
+                height: 'calc(100% - 16px)',
+                marginLeft: '17px',
+              }}
+            >
+              <Typography variant="subtitle2">
+                Sample Response
+              </Typography>
+              <Typography variant="body2">
+                {question.sampleResponse}
+              </Typography>
+            </ColorLibPaper>
+          </Grid>
+        </Grid>
+      )
+    }
+    return (
+      <Fragment>
+        <Typography variant='body1' style={{marginTop: '10px'}}> 
+          {question.question}
+        </Typography>
+        {response}
+      </Fragment>
+    )
+  }
+
+  const checkValidness = (question1Ans, question2Ans) => !(
+    question1Ans === '' || question2Ans === ''
+  );
+
+  const getButton = (submitted, isValid) => {
+    if (submitted) {
+      return (
+        <ColorLibButton 
+          variant='contained'
+          size='medium' 
+          onClick={handleNext}
+        >
+          Prepare for Live Session
+        </ColorLibButton>
+      );
+    } else {
+      return (
+        <ColorLibButton 
+          size='medium' 
+          variant={!isValid ? 'outlined' : 'contained'}
+          disabled={!isValid ? true : false}
+          onClick={handleSubmit}
+        >
+          Submit
+        </ColorLibButton>
+      );
+    }
+  };
 
 	return (
 		<Fragment>
@@ -55,7 +188,9 @@ const Refresher = () => {
           </ColorLibToggleButtonGroup>
         </Box>
         <Typography variant='h2'>
-          Complete the exercises to unlock today’s session!
+          {submitted 
+          ? "Complete the exercises to unlock today’s session!" 
+          : "Review the following before we begin the practice session."}
         </Typography>
         <Grid container style={{marginTop: '20px'}}>
           <Grid item xs={9}>
@@ -67,7 +202,7 @@ const Refresher = () => {
             <ColorLibToggleButtonGroup
               value={question1Ans}
               exclusive
-              onChange={handleQestion1}
+              onChange={handleQuestion1}
             >
               <ColorLibToggleButton size="small" value="true">
                 True
@@ -77,7 +212,7 @@ const Refresher = () => {
               </ColorLibToggleButton>
             </ColorLibToggleButtonGroup>
           </Grid>
-          {question1Ans === '' ? null :
+          {!submitted ? null :
           <ColorLibPaper elevation={9} style={{margin:'15px 0px'}}>
             <Typography variant="body2">
               {question1Ans === "false" ? "Correct!" : "Sorry, try again."} Closed questions are not “bad.” They simply are limited as a tool, so we try to avoid using them in favor of open-ended questions. However, there are situations in which closed questions are desirable. In general, the aim is to ask more open-ended than closed questions.
@@ -95,7 +230,7 @@ const Refresher = () => {
             <ColorLibToggleButtonGroup
               value={question2Ans}
               exclusive
-              onChange={handleQestion2}
+              onChange={handleQuestion2}
             >
               <ColorLibToggleButton size="small" value="true">
                 True
@@ -105,7 +240,7 @@ const Refresher = () => {
               </ColorLibToggleButton>
             </ColorLibToggleButtonGroup>
           </Grid>
-          {question2Ans === '' ? null :
+          {!submitted ? null :
           <ColorLibPaper elevation={9} style={{margin:'15px 0px'}}>
             <Typography variant="body2">
               {question2Ans === "true" ? "Correct!" : "Sorry, try again."} If we simply hold up the mirror, then we aren’t helping clients become unstuck. In addition to helping clients hear again what they’re told us, we also selectively attend to certain elements and not to others and then present that information back in a manner that helps them attain greater understanding of their situation
@@ -115,60 +250,14 @@ const Refresher = () => {
         <Typography variant='h4' style={{marginTop: '50px'}}>
           Practicing Open-ended Questions
         </Typography>
-        <Typography variant='body1' style={{marginTop: '10px'}}> 
-          Are you doing OK today?                                
-        </Typography>
-        <ColorLibTextField
-            id="outlined-secondary"
-            label="Convert the closed question to open-ended..."
-            fullWidth
-            variant="outlined"
-            multiline
-            rowsMax={2}
-            margin="normal"       
-        />
-        <Typography variant='body1' style={{marginTop: '10px'}}> 
-          How much do you drink on a typical drinking occasion?                               
-        </Typography>
-        <ColorLibTextField
-            id="outlined-secondary"
-            label="Convert the closed question to open-ended..."
-            fullWidth
-            variant="outlined"
-            multiline
-            rowsMax={2}
-            margin="normal"
-        />
-        <Typography variant='body1' style={{marginTop: '10px'}}> 
-          I don’t get what we’re supposed to be doing here.                               
-        </Typography>
-        <ColorLibTextField
-          id="outlined-secondary"
-          label="Form a question in response to the client statement..."
-          fullWidth
-          variant="outlined"
-          multiline
-          rowsMax={2}
-          margin="normal"
-        />
-        <Typography variant='body1' style={{marginTop: '10px'}}> 
-          I love my kids, but sometimes they push me to the edge, and then I do things I shouldn’t.
-        </Typography>
-        <ColorLibTextField
-            id="outlined-secondary"
-            label="Form a question in response to the client statement..."
-            fullWidth
-            variant="outlined"
-            multiline
-            rowsMax={2}
-            margin="normal"
-        />
+        {openEndedQuestions.map(ques => getOpenEndQuestionSet(ques, submitted))}
       </Container>
       
-			<div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '20px 0px 50px 0px'}}>
-        <ColorLibButton variant='outlined' size='medium' onClick={handleNext}>
-          Submit
-        </ColorLibButton>
+			<div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '50px 0px'}}>
+        {getButton(
+          submitted, 
+          checkValidness(question1Ans, question2Ans)
+        )}
 			</div>
 			
 		</Fragment>

--- a/src/components/layout/Refresher.jsx
+++ b/src/components/layout/Refresher.jsx
@@ -178,6 +178,7 @@ const Refresher = () => {
             value={userMode}
             exclusive
             onChange={handleUserMode}
+            disabled={submitted}
           >
             <ColorLibToggleButton size="small" value="caller">
               Caller
@@ -204,10 +205,10 @@ const Refresher = () => {
               exclusive
               onChange={handleQuestion1}
             >
-              <ColorLibToggleButton size="small" value="true">
+              <ColorLibToggleButton size="small" value="true" disabled={submitted}>
                 True
               </ColorLibToggleButton>
-              <ColorLibToggleButton size="small" value="false">
+              <ColorLibToggleButton size="small" value="false" disabled={submitted}>
                 False
               </ColorLibToggleButton>
             </ColorLibToggleButtonGroup>
@@ -232,10 +233,10 @@ const Refresher = () => {
               exclusive
               onChange={handleQuestion2}
             >
-              <ColorLibToggleButton size="small" value="true">
+              <ColorLibToggleButton size="small" value="true" disabled={submitted}>
                 True
               </ColorLibToggleButton>
-              <ColorLibToggleButton size="small" value="false">
+              <ColorLibToggleButton size="small" value="false" disabled={submitted}>
                 False
               </ColorLibToggleButton>
             </ColorLibToggleButtonGroup>

--- a/src/components/layout/Refresher.jsx
+++ b/src/components/layout/Refresher.jsx
@@ -1,10 +1,10 @@
 import React, {useState} from 'react';
 import { Box, Container } from '@material-ui/core';
-import {ToggleButton, ToggleButtonGroup } from '@material-ui/lab';
 import { Fragment } from 'react';
 import { useUserModeValue, useActiveStepValue } from '../../context';
 import ColorLibButton from './ColorLibComponents/ColorLibButton';
 import ColorLibTextField from './ColorLibComponents/ColorLibTextField';
+import ColorLibToggleButton, { ColorLibToggleButtonGroup } from './ColorLibComponents/ColorLibToggleButton';
 
 const Refresher = () => {
 	const {curActiveStep: activeStep, setCurActiveStep: setActiveStep} = useActiveStepValue();
@@ -39,18 +39,18 @@ const Refresher = () => {
 		<Fragment>
       <Container maxWidth='md'>
         <Box align="left" m = {2}> 
-          <ToggleButtonGroup
+          <ColorLibToggleButtonGroup
             value={userMode}
             exclusive
             onChange={handleUserMode}
           >
-            <ToggleButton value="caller" aria-label="left aligned">
+            <ColorLibToggleButton size="small" value="caller" aria-label="left aligned">
               caller
-            </ToggleButton>
-            <ToggleButton value="callee" aria-label="centered">
+            </ColorLibToggleButton>
+            <ColorLibToggleButton size="small" value="callee" aria-label="centered">
               callee
-            </ToggleButton>
-          </ToggleButtonGroup>
+            </ColorLibToggleButton>
+          </ColorLibToggleButtonGroup>
         </Box>
         <Box fontStyle="normal" fontSize={25} textAlign="center" fontWeight="fontWeightBold" >
           Complete the exercises to unlock today's session!
@@ -60,18 +60,18 @@ const Refresher = () => {
           Closed questions are bad.
           </Box>
           <Box align="left" m = {2}>          
-            <ToggleButtonGroup
+            <ColorLibToggleButtonGroup
               value={question1Ans}
               exclusive
               onChange={handleQestion1}
             >
-              <ToggleButton value="true" aria-label="left aligned">
+              <ColorLibToggleButton size="small" value="true" aria-label="left aligned">
                 True
-              </ToggleButton>
-              <ToggleButton value="false" aria-label="centered">
+              </ColorLibToggleButton>
+              <ColorLibToggleButton size="small" value="false" aria-label="centered">
                 False
-              </ToggleButton>
-            </ToggleButtonGroup>
+              </ColorLibToggleButton>
+            </ColorLibToggleButtonGroup>
           </Box>  
         </div>
         {question1Ans === '' ? null :
@@ -83,18 +83,18 @@ const Refresher = () => {
             We use reflections to help clients not only see what they've told us, but to also help organize and understand their experience.
           </Box>
           <Box align="left" m = {2}>          
-            <ToggleButtonGroup
+            <ColorLibToggleButtonGroup
               value={question2Ans}
               exclusive
               onChange={handleQestion2}
             >
-              <ToggleButton value="true" aria-label="left aligned">
+              <ColorLibToggleButton size="small" value="true" aria-label="left aligned">
                 True
-              </ToggleButton>
-              <ToggleButton value="false" aria-label="centered">
+              </ColorLibToggleButton>
+              <ColorLibToggleButton size="small" value="false" aria-label="centered">
                 False
-              </ToggleButton>
-            </ToggleButtonGroup>
+              </ColorLibToggleButton>
+            </ColorLibToggleButtonGroup>
           </Box>  
         </div>
         {question2Ans === '' ? null :

--- a/src/components/layout/Refresher.jsx
+++ b/src/components/layout/Refresher.jsx
@@ -1,10 +1,12 @@
 import React, {useState} from 'react';
-import { Box, Container } from '@material-ui/core';
+import { Box, Container, Grid } from '@material-ui/core';
 import { Fragment } from 'react';
 import { useUserModeValue, useActiveStepValue } from '../../context';
 import ColorLibButton from './ColorLibComponents/ColorLibButton';
 import ColorLibTextField from './ColorLibComponents/ColorLibTextField';
 import ColorLibToggleButton, { ColorLibToggleButtonGroup } from './ColorLibComponents/ColorLibToggleButton';
+import ColorLibPaper from './ColorLibComponents/ColorLibPaper';
+import Typography from '@material-ui/core/Typography';
 
 const Refresher = () => {
 	const {curActiveStep: activeStep, setCurActiveStep: setActiveStep} = useActiveStepValue();
@@ -44,100 +46,115 @@ const Refresher = () => {
             exclusive
             onChange={handleUserMode}
           >
-            <ColorLibToggleButton size="small" value="caller" aria-label="left aligned">
-              caller
+            <ColorLibToggleButton size="small" value="caller">
+              Caller
             </ColorLibToggleButton>
-            <ColorLibToggleButton size="small" value="callee" aria-label="centered">
-              callee
+            <ColorLibToggleButton size="small" value="callee">
+              Callee
             </ColorLibToggleButton>
           </ColorLibToggleButtonGroup>
         </Box>
-        <Box fontStyle="normal" fontSize={25} textAlign="center" fontWeight="fontWeightBold" >
-          Complete the exercises to unlock today's session!
-        </Box>
-        <div style={{ display: 'flex' }}>
-          <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" m={3.5}> 
-          Closed questions are bad.
-          </Box>
-          <Box align="left" m = {2}>          
+        <Typography variant='h2'>
+          Complete the exercises to unlock today’s session!
+        </Typography>
+        <Grid container style={{marginTop: '20px'}}>
+          <Grid item xs={9}>
+            <Typography variant='body1' style={{marginRight: '12px'}}>
+              Closed questions are bad.
+            </Typography>
+          </Grid>
+          <Grid item xs={3}>
             <ColorLibToggleButtonGroup
               value={question1Ans}
               exclusive
               onChange={handleQestion1}
             >
-              <ColorLibToggleButton size="small" value="true" aria-label="left aligned">
+              <ColorLibToggleButton size="small" value="true">
                 True
               </ColorLibToggleButton>
-              <ColorLibToggleButton size="small" value="false" aria-label="centered">
+              <ColorLibToggleButton size="small" value="false">
                 False
               </ColorLibToggleButton>
             </ColorLibToggleButtonGroup>
-          </Box>  
-        </div>
-        {question1Ans === '' ? null :
-        <Box fontStyle="italic" pl = {3.5} textAlign="left" fontSize={16} fontWeight="fontWeightMedium">
-          {question1Ans === "false" ? "Correct!" : "Sorry, try again."} Closed questions are not “bad.” They simply are limited as a tool, so we try to avoid using them in favor of open-ended questions. However, there are situations in which closed questions are desirable. In general, the aim is to ask more open-ended than closed questions.
-        </Box>}
-        <div style={{ display: 'flex' }}>
-          <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" m={3.5}> 
-            We use reflections to help clients not only see what they've told us, but to also help organize and understand their experience.
-          </Box>
-          <Box align="left" m = {2}>          
+          </Grid>
+          {question1Ans === '' ? null :
+          <ColorLibPaper elevation={9} style={{margin:'15px 0px'}}>
+            <Typography variant="body2">
+              {question1Ans === "false" ? "Correct!" : "Sorry, try again."} Closed questions are not “bad.” They simply are limited as a tool, so we try to avoid using them in favor of open-ended questions. However, there are situations in which closed questions are desirable. In general, the aim is to ask more open-ended than closed questions.
+            </Typography>
+          </ColorLibPaper>
+          }
+        </Grid>
+        <Grid container style={{marginTop: '20px'}}>
+          <Grid item xs={9}>
+            <Typography variant='body1' style={{marginRight: '12px'}}> 
+              We use reflections to help clients not only see what they've told us, but to also help organize and understand their experience.
+            </Typography>
+          </Grid>
+          <Grid item xs={3}>        
             <ColorLibToggleButtonGroup
               value={question2Ans}
               exclusive
               onChange={handleQestion2}
             >
-              <ColorLibToggleButton size="small" value="true" aria-label="left aligned">
+              <ColorLibToggleButton size="small" value="true">
                 True
               </ColorLibToggleButton>
-              <ColorLibToggleButton size="small" value="false" aria-label="centered">
+              <ColorLibToggleButton size="small" value="false">
                 False
               </ColorLibToggleButton>
             </ColorLibToggleButtonGroup>
-          </Box>  
-        </div>
-        {question2Ans === '' ? null :
-        <Box fontStyle="italic" pl = {3.5} textAlign="left" fontSize={16} fontWeight="fontWeightMedium">
-          {question2Ans === "true" ? "Correct!" : "Sorry, try again."} If we simply hold up the mirror, then we aren’t helping clients become unstuck. In addition to helping clients hear again what they’re told us, we also selectively attend to certain elements and not to others and then present that information back in a manner that helps them attain greater understanding of their situation
-        </Box>}
-
-        <Box pt = {1} fontStyle="normal" fontSize={20} textAlign="center" fontWeight="fontWeightBold" >
+          </Grid>
+          {question2Ans === '' ? null :
+          <ColorLibPaper elevation={9} style={{margin:'15px 0px'}}>
+            <Typography variant="body2">
+              {question2Ans === "true" ? "Correct!" : "Sorry, try again."} If we simply hold up the mirror, then we aren’t helping clients become unstuck. In addition to helping clients hear again what they’re told us, we also selectively attend to certain elements and not to others and then present that information back in a manner that helps them attain greater understanding of their situation
+            </Typography>
+          </ColorLibPaper>}
+        </Grid>
+        <Typography variant='h4' style={{marginTop: '50px'}}>
           Practicing Open-ended Questions
-        </Box>
-        <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" pl={3.5}> 
+        </Typography>
+        <Typography variant='body1' style={{marginTop: '10px'}}> 
           Are you doing OK today?                                
-        </Box>
-        <Box pl = {3.5} width = {900} >
-          <ColorLibTextField
-              id="outlined-secondary"
-              label="Convert the closed question to open-ended..."
-              fullWidth
-              variant="outlined"
-              multiline
-              rowsMax={2}
-              margin="normal"       
-          />
-        </Box>
-        <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" pl={3.5}> 
+        </Typography>
+        <ColorLibTextField
+            id="outlined-secondary"
+            label="Convert the closed question to open-ended..."
+            fullWidth
+            variant="outlined"
+            multiline
+            rowsMax={2}
+            margin="normal"       
+        />
+        <Typography variant='body1' style={{marginTop: '10px'}}> 
           How much do you drink on a typical drinking occasion?                               
-        </Box>
-        <Box pl = {3.5} width = {900} >
-          <ColorLibTextField
-              id="outlined-secondary"
-              label="Convert the closed question to open-ended..."
-              fullWidth
-              variant="outlined"
-              multiline
-              rowsMax={2}
-              margin="normal"
-          />
-        </Box>
-        <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" pl={3.5}> 
+        </Typography>
+        <ColorLibTextField
+            id="outlined-secondary"
+            label="Convert the closed question to open-ended..."
+            fullWidth
+            variant="outlined"
+            multiline
+            rowsMax={2}
+            margin="normal"
+        />
+        <Typography variant='body1' style={{marginTop: '10px'}}> 
           I don’t get what we’re supposed to be doing here.                               
-        </Box>
-        <Box pl = {3.5} width = {900} >
-          <ColorLibTextField
+        </Typography>
+        <ColorLibTextField
+          id="outlined-secondary"
+          label="Form a question in response to the client statement..."
+          fullWidth
+          variant="outlined"
+          multiline
+          rowsMax={2}
+          margin="normal"
+        />
+        <Typography variant='body1' style={{marginTop: '10px'}}> 
+          I love my kids, but sometimes they push me to the edge, and then I do things I shouldn’t.
+        </Typography>
+        <ColorLibTextField
             id="outlined-secondary"
             label="Form a question in response to the client statement..."
             fullWidth
@@ -145,22 +162,7 @@ const Refresher = () => {
             multiline
             rowsMax={2}
             margin="normal"
-          />
-        </Box>
-        <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" pl={3.5}> 
-          I love my kids, but sometimes they push me to the edge, and then I do things I shouldn’t.
-        </Box>
-        <Box pl = {3.5} width = {900} >
-          <ColorLibTextField
-              id="outlined-secondary"
-              label="Form a question in response to the client statement..."
-              fullWidth
-              variant="outlined"
-              multiline
-              rowsMax={2}
-              margin="normal"
-          />
-        </Box>
+        />
       </Container>
       
 			<div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '20px 0px 50px 0px'}}>

--- a/src/components/layout/SelfReflection.jsx
+++ b/src/components/layout/SelfReflection.jsx
@@ -6,12 +6,6 @@ import ColorLibButton, { ColorLibNextButton, ColorLibBackButton } from './ColorL
 import ColorLibTextField from './ColorLibComponents/ColorLibTextField';
 import ColorLibPaper from './ColorLibComponents/ColorLibPaper';
 
-const useStyles = makeStyles((theme) => ({
-    page: {
-        margin: '24px 0px',
-    },
-}));
-
 const getPageTitle = (page) => {
     switch(page) {
         case 0: return "Based on today’s session";
@@ -178,14 +172,16 @@ const getPageButtons = (page, setPage) => {
 
 const SelfReflection = () => {
     const [page, setPage] = useState(0);
-    const classes = useStyles();
 
     return (
         <Container maxWidth = 'md'>
             <Typography variant='h2'>
                 Reflect on how the session went and how you felt.
             </Typography>
-            <ColorLibPaper className={classes.page}>
+            <ColorLibPaper 
+                elevation={0}
+                style={{margin:'24px 0px'}}
+            >
                 <Typography variant='h4'>
                     {getPageTitle(page)}
                 </Typography>  

--- a/src/components/layout/SelfReflection.jsx
+++ b/src/components/layout/SelfReflection.jsx
@@ -7,16 +7,8 @@ import ColorLibTextField from './ColorLibComponents/ColorLibTextField';
 import ColorLibPaper from './ColorLibComponents/ColorLibPaper';
 
 const useStyles = makeStyles((theme) => ({
-    title: {
-        fontSize: '25px',
-        fontWeight: '600',
-    },
     page: {
         margin: '24px 0px',
-    },
-    pageTitle: {
-        fontSize: '20px',
-        fontWeight: '600',
     },
 }));
 
@@ -190,11 +182,11 @@ const SelfReflection = () => {
 
     return (
         <Container maxWidth = 'md'>
-            <Typography className={classes.title}>
+            <Typography variant='h2'>
                 Reflect on how the session went and how you felt.
             </Typography>
             <ColorLibPaper className={classes.page}>
-                <Typography className={classes.pageTitle}>
+                <Typography variant='h4'>
                     {getPageTitle(page)}
                 </Typography>  
                 {getPageContent(page)}


### PR DESCRIPTION
### Description
1. After the Submit button is clicked on MI Refresher page, the user should to directed to a page where they can review their submission (See JIRA task [MFP-8](https://mi-summer-project.atlassian.net/browse/MFP-8))
2. The website uses a combination of Poppins and Karla font, but currently we only have Poppins and most use cases of the Typography component are hard-coded. 
3. The style of the MI Refresher page needs refining.

### Changes
1. A submission review page is created.
    - A simple `checkValidness` function is created so that unless the users have finished answering the questions, the submit button would be disabled.
    - After the submit button is clicked, the users would be led to a page with their submitted responses. (Note that the current submitted responses displayed are all hard-coded placeholders. We still need to set up the database first to make real submission possible.)
2. The theme defined in App.js is updated to have a set of typographies that corresponds with the typographies used on Figma.
    - It currently contains: h1, h2, h3, h4, subtitle1, subtitle2, body1, body2.
    - h1, h2, h3, h4 strictly correspond to the headings in Figma.
    - body1 and body2 respectively correspond to "text" and "small text" in Figma.
    - subtitle1 and subtitle2 are respectively the bold versions of body1 and body2.
3. The refresher page now matches perfectly with the Figma design
    - The ColorLibPaper component is updated to allow the card-like display of the submitted and sample responses.
    - The newly defined typographies are applied.

Current Refresher Page:

https://user-images.githubusercontent.com/55717622/133950228-8c586f0e-ce8e-49dc-aa08-fb5be6f0a788.mov