### PR TITLE
General Style Update; Fixing previous TextField bugs

### DIFF
--- a/src/components/DissResponse.js
+++ b/src/components/DissResponse.js
@@ -1,8 +1,9 @@
-import React, {useState, useRef, useEffect} from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
-import {formatTime} from '../helper/index';
-import { Box, Grid, Paper } from '@material-ui/core';
+import { formatTime } from '../helper/index';
+import { Box, Grid, Paper, Typography } from '@material-ui/core';
 import { ToggleButton } from '@material-ui/lab';
+import ColorLibPaper from './layout/ColorLibComponents/ColorLibPaper';
 import ColorLibTextField from './layout/ColorLibComponents/ColorLibTextField';
 import MISkillsSheet from './layout/MISkillsSheet';
 
@@ -12,28 +13,34 @@ import { firebase } from "../hooks/firebase";
 
 //context
 import { useSessionValue, useUserModeValue } from '../context';
+import { format } from 'url';
 
 const useStyles = makeStyles((theme) => ({
     root: {
         display: 'flex',
         '& > *': {
-            margin: theme.spacing(2),
-            width: 'auto',
+            width: '100%',
+            '&:first-child': {
+                marginRight: '8px',
+            },
+            '&:last-child': {
+                marginLeft: '8px',
+            }
         },
     },
 }));
 
-const DissResponse = ({curPinIndex}) => {   
+const DissResponse = ({ curPinIndex }) => {
     // user mode switcher
-    const {userMode} = useUserModeValue();
-    
+    const { userMode } = useUserModeValue();
+
     const classes = useStyles();
-    
+
     //creating a refernce for TextField Component
-    const noteValueRef = useRef('') 
+    const noteValueRef = useRef('')
 
     //get sessionID
-    const {sessionID} = useSessionValue();
+    const { sessionID } = useSessionValue();
 
     // fetch raw pin data here
     const [pins, setPins] = useState([]);
@@ -82,29 +89,29 @@ const DissResponse = ({curPinIndex}) => {
                 console.log("No such document!");
             }
         })
-        .catch((error) => {
-            console.log("Error getting document:", error);
-        });
-        if(infoName === `${userMode}PinInfos.pinNote`){
+            .catch((error) => {
+                console.log("Error getting document:", error);
+            });
+        if (infoName === `${userMode}PinInfos.pinNote`) {
             setCurNoteInfo(doc);
-        } else if(infoName === `callerPinInfos.pinPerspective`){
+        } else if (infoName === `callerPinInfos.pinPerspective`) {
             setCurPerspectiveInfo1(doc);
-        } else if(infoName === `calleePinInfos.pinPerspective`){
+        } else if (infoName === `calleePinInfos.pinPerspective`) {
             setCurPerspectiveInfo2(doc);
-        } else if(infoName === `callerPinInfos.pinCategory`){
+        } else if (infoName === `callerPinInfos.pinCategory`) {
             setPinType1(doc);
-        } else if(infoName === `calleePinInfos.pinCategory`){
+        } else if (infoName === `calleePinInfos.pinCategory`) {
             setPinType2(doc);
-        } else if(infoName === `callerPinInfos.pinSkill`){
+        } else if (infoName === `callerPinInfos.pinSkill`) {
             setCurSkillInfo1(doc);
-        } else if(infoName === `calleePinInfos.pinSkill`){
+        } else if (infoName === `calleePinInfos.pinSkill`) {
             setCurSkillInfo2(doc);
         }
     }
 
     // for pin information modifying
     const handlePinInfo = (infoName, input) => {
-        if(infoName === `${userMode}PinInfos.pinNote`){
+        if (infoName === `${userMode}PinInfos.pinNote`) {
             setCurNoteInfo(input);
         }
         let usersUpdate = {};
@@ -112,8 +119,8 @@ const DissResponse = ({curPinIndex}) => {
         firebase
             .firestore()
             .collection("Pins")
-            .doc(formatTime(pins.map(pin => pin.pinTime)[curPinIndex]))        
-            .update(usersUpdate)    
+            .doc(formatTime(pins.map(pin => pin.pinTime)[curPinIndex]))
+            .update(usersUpdate)
             .then(() => {
                 console.log("Document successfully updated!");
             })
@@ -125,31 +132,41 @@ const DissResponse = ({curPinIndex}) => {
 
     return (
         <Grid item xs={12} sm={8}>
-            <Paper >
-                <h2>{userMode}</h2>
+            <ColorLibPaper >
+                <Typography variant="h4" style={{ textTransform: 'capitalize' }}>
+                    {userMode}
+                </Typography>
                 {/* <Button variant="contained" onClick = {() => handleUserModeSwitch()}>userMode switcher</Button> */}
-                <Box m={2} height={700}>
-                    <Box fontStyle="italic" fontSize={18}>
+                <Box fontStyle="italic">
+                    <Typography>
                         Pinned at {formatTime(pins.map(pin => pin.pinTime)[curPinIndex])}
-                    </Box>
-                    <ColorLibTextField
-                        disabled
-                        id="outlined-secondary"
-                        label="Personal Notes..."
-                        fullWidth
-                        variant="outlined"
-                        multiline
-                        rows={3}
-                        margin="normal"
-                        value = {curNoteInfo}
-                        inputRef={noteValueRef}
-                        onChange = {() => handlePinInfo(`${userMode}PinInfos.pinNote`, noteValueRef.current.value)}
-                    />
-                    <Box my={1} fontStyle="italic" fontSize={18}> Talk with your peer about:</Box>
-                    <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" m={2}> 
-                        What is your perspective of what happened at this pin? 
-                    </Box>
-                    <form className={classes.root} noValidate autoComplete="off">
+                    </Typography>
+                </Box>
+                <ColorLibTextField
+                    disabled
+                    id="outlined-secondary"
+                    label="Personal Notes..."
+                    fullWidth
+                    variant="outlined"
+                    multiline
+                    rows={3}
+                    margin="normal"
+                    value={curNoteInfo}
+                    inputRef={noteValueRef}
+                    onChange={() => handlePinInfo(`${userMode}PinInfos.pinNote`, noteValueRef.current.value)}
+                />
+                <Box fontStyle="italic" marginTop="30px"> 
+                    <Typography variant="h3">
+                        Talk with your peer about:
+                    </Typography>
+                </Box>
+                <Box textAlign="left">
+                    <Typography>
+                        What is your perspective of what happened at this pin?
+                    </Typography>
+                </Box>
+                <form className={classes.root} noValidate autoCo
+                mplete="off">
                     <ColorLibTextField
                         disabled
                         id="outlined-secondary"
@@ -158,8 +175,8 @@ const DissResponse = ({curPinIndex}) => {
                         variant="outlined"
                         multiline
                         rows={3}
-                        margin="normal"                        
-                        value = {curPerspectiveInfo1}
+                        margin="normal"
+                        value={curPerspectiveInfo1}
                     />
                     <ColorLibTextField
                         disabled
@@ -170,62 +187,65 @@ const DissResponse = ({curPinIndex}) => {
                         multiline
                         rows={3}
                         margin="normal"
-                        value = {curPerspectiveInfo2}
+                        value={curPerspectiveInfo2}
                     />
-                    </form>
-                    <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" m={1}> 
+                </form>
+                <Box textAlign="left">
+                    <Typography>
                         What would you categorize this pin as?
-                    </Box>       
-                    <form className={classes.root} noValidate autoComplete="off">
-                        <ToggleButton >
-                            {pinType1}
-                        </ToggleButton>
-                        <ToggleButton >
-                            {pinType2}
-                        </ToggleButton>
-                    </form>
-                    <MISkillsSheet />
-                    <form className={classes.root} noValidate autoComplete="off">
-                        <ColorLibTextField
-                            disabled
-                            id="outlined-secondary"
-                            label="caller's MI skill"
-                            fullWidth
-                            variant="outlined"
-                            multiline
-                            rows={1}
-                            margin="normal"
-                            value = {curSkillInfo1}
-                        />
-                        <ColorLibTextField
-                            disabled
-                            id="outlined-secondary"
-                            label="callee's MI skill"
-                            fullWidth
-                            variant="outlined"
-                            multiline
-                            rows={1}
-                            margin="normal"                        
-                            value = {curSkillInfo2}
-                        />
-                    </form>
-
-                    <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" m={1}> 
-                        Why was the pinned situation effective or ineffective?
-                    </Box>  
+                    </Typography>
+                </Box>
+                <form className={classes.root} noValidate autoComplete="off">
+                    <ToggleButton >
+                        {pinType1}
+                    </ToggleButton>
+                    <ToggleButton >
+                        {pinType2}
+                    </ToggleButton>
+                </form>
+                <MISkillsSheet />
+                <form className={classes.root} noValidate autoComplete="off">
                     <ColorLibTextField
+                        disabled
                         id="outlined-secondary"
+                        label="caller's MI skill"
                         fullWidth
                         variant="outlined"
                         multiline
-                        rowsMax={2}
+                        rows={1}
                         margin="normal"
-                        // value = {curSkillInfo}
-                        // inputRef={skillValueRef}
-                        // onChange = {() => handlePinInfo("pinInfos.pinSkill", skillValueRef.current.value)}
+                        value={curSkillInfo1}
                     />
+                    <ColorLibTextField
+                        disabled
+                        id="outlined-secondary"
+                        label="callee's MI skill"
+                        fullWidth
+                        variant="outlined"
+                        multiline
+                        rows={1}
+                        margin="normal"
+                        value={curSkillInfo2}
+                    />
+                </form>
+
+                <Box textAlign="left">
+                    <Typography>
+                        Why was the pinned situation effective or ineffective?
+                        </Typography>
                 </Box>
-            </Paper>
+                <ColorLibTextField
+                    id="outlined-secondary"
+                    fullWidth
+                    variant="outlined"
+                    multiline
+                    rowsMax={2}
+                    margin="normal"
+                // value = {curSkillInfo}
+                // inputRef={skillValueRef}
+                // onChange = {() => handlePinInfo("pinInfos.pinSkill", skillValueRef.current.value)}
+                />
+            </ColorLibPaper>
 
         </Grid>
     );

--- a/src/components/Notetaking.js
+++ b/src/components/Notetaking.js
@@ -118,9 +118,9 @@ const Notetaking = ({ curPinIndex, setCurPinIndex }) => {
     useEffect(() => {
         console.log("Current pin Index: ", curPinIndex);
         //update pin values
-        setCurNoteInfo(noteValueRef.current);
-        setCurPerspectiveInfo(perspectiveValueRef.current);
-        setCurSkillInfo(skillValueRef.current);
+        setCurNoteInfo(noteValueRef.current.value);
+        setCurPerspectiveInfo(perspectiveValueRef.current.value);
+        setCurSkillInfo(skillValueRef.current.value);
         //save pin info
         savePin(curPinIndex);
         //clear out all the states
@@ -131,9 +131,9 @@ const Notetaking = ({ curPinIndex, setCurPinIndex }) => {
             setCurSkillInfo(pins[curPinIndex].pinInfos.pinSkill);
         }
         //reset all the refs
-        noteValueRef.current
+        noteValueRef.current.value
             = curNoteInfo;
-        perspectiveValueRef.current = curPerspectiveInfo;
+        perspectiveValueRef.current.value = curPerspectiveInfo;
         skillValueRef.current = curSkillInfo;
     }, [curPinIndex])
 

--- a/src/components/Notetaking.js
+++ b/src/components/Notetaking.js
@@ -1,12 +1,12 @@
-import React, {useState, useRef, useEffect} from 'react';
-import {formatTime} from '../helper/index';
-import { Box, Grid, Paper, Fab, Button } from '@material-ui/core';
-import {ToggleButton, ToggleButtonGroup } from '@material-ui/lab';
+import React, { useState, useRef, useEffect } from 'react';
+import { formatTime } from '../helper/index';
+
+import { makeStyles } from '@material-ui/core/styles';
+import { Box, Grid, Typography } from '@material-ui/core';
+import { ToggleButton, ToggleButtonGroup } from '@material-ui/lab';
+import ColorLibPaper from './layout/ColorLibComponents/ColorLibPaper';
 import ColorLibTextField from './layout/ColorLibComponents/ColorLibTextField';
 import MISkillsSheet from './layout/MISkillsSheet';
-import NavigateBeforeIcon from '@material-ui/icons/NavigateBefore';
-import NavigateNextIcon from '@material-ui/icons/NavigateNext';
-import ReactPlayer from 'react-player';
 
 // firebase hook
 import { usePins } from '../hooks/index';
@@ -16,16 +16,48 @@ import { firebase } from "../hooks/firebase";
 import { useUserModeValue } from '../context';
 import { useSessionValue, usePinsValue } from "../context";
 
+const useStyles = makeStyles(theme => ({
+    toggleGroup: {
+        marginTop: '8px',
+        marginBottom: '16px',
+        width: '100%',
+        height: '40px',
+        '& .MuiToggleButton-root': {
+            backgroundColor: 'white',
+            borderColor: theme.palette.teal.main,
+            borderWidth: '2px',
+            color: theme.palette.teal.main,
+            textTransform: 'none',
+            width: '100%',
+            '&.Mui-selected': {
+                backgroundColor: theme.palette.teal.light,
+            }
+        },
+        '& .MuiToggleButtonGroup-groupedHorizontal:first-child': {
+            borderTopLeftRadius: '35px',
+            borderBottomLeftRadius: '35px',
+        },
+        '& .MuiToggleButtonGroup-groupedHorizontal:last-child': {
+            borderTopRightRadius: '35px',
+            borderBottomRightRadius: '35px',
+        },
+        '& .MuiToggleButtonGroup-groupedHorizontal:not(:first-child)': {
+            marginLeft: '3px',
+        }
+    },
+}));
 
-const Notetaking = ({curPinIndex, setCurPinIndex}) => {    
+const Notetaking = ({ curPinIndex, setCurPinIndex }) => {
+    const classes = useStyles();
+
     //creating a refernce for TextField Component
     const player = useRef(null);
-    const noteValueRef = useRef('') 
+    const noteValueRef = useRef('')
     const perspectiveValueRef = useRef('')
     const skillValueRef = useRef('')
 
     //session values
-    const {sessionID, mediaUrl: audio, setMediaUrl, setMediaDuration,mediaDuration: audioLen} = useSessionValue();
+    const { sessionID, mediaUrl: audio, setMediaUrl, setMediaDuration, mediaDuration: audioLen } = useSessionValue();
 
     // fetch raw pin data here
     const { pins } = usePinsValue();
@@ -35,22 +67,22 @@ const Notetaking = ({curPinIndex, setCurPinIndex}) => {
     const [curNoteInfo, setCurNoteInfo] = useState('');
     const [curPerspectiveInfo, setCurPerspectiveInfo] = useState('');
     const [curSkillInfo, setCurSkillInfo] = useState('');
-    const [pinBtnDisabled, setPinBtnDisabled] = useState(false); 
+    const [pinBtnDisabled, setPinBtnDisabled] = useState(false);
     const [pinBtnColor, setPinBtnColor] = useState("");
     const [audioProgress, setAudioProgress] = useState(0);
     const [loadURL, setLoadURL] = useState(false)
 
     // user mode switcher
-    const {userMode} = useUserModeValue();
+    const { userMode } = useUserModeValue();
 
     console.log(pins);
 
     // back to last pin
-    const handleLastPin = (index) => {   
+    const handleLastPin = (index) => {
         console.log(audio);
         console.log(audioLen);
         console.log(audioProgress);
-        if(curPinIndex > 0){
+        if (curPinIndex > 0) {
             setCurPinIndex(index);
             player.current.seekTo(parseFloat(pins.map(pin => pin.pinTime)[index]));
         }
@@ -58,11 +90,11 @@ const Notetaking = ({curPinIndex, setCurPinIndex}) => {
 
     // go to next pin
     const handleNextPin = (index, remove = false) => {
-        if(curPinIndex < pins.map(pin => pin.pinTime).length - 1){
-            if(!remove){
+        if (curPinIndex < pins.map(pin => pin.pinTime).length - 1) {
+            if (!remove) {
                 player.current.seekTo(parseFloat(pins.map(pin => pin.pinTime)[index]));
                 setCurPinIndex(index);
-            } else{                
+            } else {
                 player.current.seekTo(parseFloat(pins.map(pin => pin.pinTime)[index]));
                 setCurPinIndex(index - 1);
             }
@@ -70,16 +102,17 @@ const Notetaking = ({curPinIndex, setCurPinIndex}) => {
     };
 
     const savePin = async (index) => {
-        console.log("pins:" + pins +"\nindex: " + index);
-        if(index >= 0)
-        {
+        console.log("pins:" + pins + "\nindex: " + index);
+        if (index >= 0) {
             const myPin = pins[index];
-            myPin.pinInfos.pinNote = curNoteInfo;
-            myPin.pinInfos.pinPersepective = curPerspectiveInfo;
-            myPin.pinInfos.pinCategory = pinType;
-            myPin.pinInfos.pinSkill = curSkillInfo;
-            pins[index] = myPin;
-        }        
+            if (myPin) {
+                myPin.pinInfos.pinNote = curNoteInfo;
+                myPin.pinInfos.pinPersepective = curPerspectiveInfo;
+                myPin.pinInfos.pinCategory = pinType;
+                myPin.pinInfos.pinSkill = curSkillInfo;
+                pins[index] = myPin;
+            }
+        }
     }
 
     useEffect(() => {
@@ -91,21 +124,23 @@ const Notetaking = ({curPinIndex, setCurPinIndex}) => {
         //save pin info
         savePin(curPinIndex);
         //clear out all the states
-        setPinType(pins[curPinIndex].pinInfos.pinCategory);
-        setCurNoteInfo(pins[curPinIndex].pinInfos.pinNote);
-        setCurPerspectiveInfo(pins[curPinIndex].pinInfos.pinPersepective);
-        setCurSkillInfo(pins[curPinIndex].pinInfos.pinSkill);
+        if (pins[curPinIndex]) {
+            setPinType(pins[curPinIndex].pinInfos.pinCategory);
+            setCurNoteInfo(pins[curPinIndex].pinInfos.pinNote);
+            setCurPerspectiveInfo(pins[curPinIndex].pinInfos.pinPersepective);
+            setCurSkillInfo(pins[curPinIndex].pinInfos.pinSkill);
+        }
         //reset all the refs
-        noteValueRef.current 
-        = curNoteInfo;
+        noteValueRef.current
+            = curNoteInfo;
         perspectiveValueRef.current = curPerspectiveInfo;
         skillValueRef.current = curSkillInfo;
     }, [curPinIndex])
-    
+
 
     // for updating and fetching current text field value
     const fetchCurTextVal = async (infoName) => {
-        return 
+        return
         const docId = pins[curPinIndex].pinID;
         const docRef = await firebase.firestore().collection("sessions").doc(sessionID).collection('pins').doc(pins[curPinIndex].pinID);
         const infos = infoName.split(".");
@@ -119,29 +154,29 @@ const Notetaking = ({curPinIndex, setCurPinIndex}) => {
                 console.log("No such document!");
             }
         })
-        .catch((error) => {
-            console.log("Error getting document:", error);
-        });
-        if(infoName === `${userMode}PinInfos.pinNote`){
+            .catch((error) => {
+                console.log("Error getting document:", error);
+            });
+        if (infoName === `${userMode}PinInfos.pinNote`) {
             setCurNoteInfo(doc);
-        } else if(infoName === `${userMode}PinInfos.pinPerspective`){
+        } else if (infoName === `${userMode}PinInfos.pinPerspective`) {
             setCurPerspectiveInfo(doc);
-        } else if(infoName === `${userMode}PinInfos.pinCategory`){
+        } else if (infoName === `${userMode}PinInfos.pinCategory`) {
             setPinType(doc);
-        } else if(infoName === `${userMode}PinInfos.pinSkill`){
+        } else if (infoName === `${userMode}PinInfos.pinSkill`) {
             setCurSkillInfo(doc);
-        } 
+        }
     }
 
     // for pin information modifying
     const handlePinInfo = (infoName, input) => {
-        if(infoName === `${userMode}PinInfos.pinNote`){
+        if (infoName === `${userMode}PinInfos.pinNote`) {
             setCurNoteInfo(input);
-        } else if(infoName === `${userMode}PinInfos.pinPerspective`){
+        } else if (infoName === `${userMode}PinInfos.pinPerspective`) {
             setCurPerspectiveInfo(input);
-        } else if(infoName === `${userMode}PinInfos.pinSkill`){
+        } else if (infoName === `${userMode}PinInfos.pinSkill`) {
             setCurSkillInfo(input);
-        } 
+        }
         // let usersUpdate = {};
         // usersUpdate[`${infoName}`] = input;
         // firebase
@@ -162,81 +197,91 @@ const Notetaking = ({curPinIndex, setCurPinIndex}) => {
     const handlePinType = (event, newPinType) => {
         setPinType(newPinType);
         // handlePinInfo(`${userMode}PinInfos.pinCategory`, newPinType);
-    };  
+    };
 
     return (
         <Grid item xs={12} sm={8}>
-            <Paper >
-                <h2>{userMode}</h2>
-                {/* <Button variant="contained" onClick = {() => handleUserModeSwitch()}>userMode switcher</Button> */}
-                <Box m={2} height={600} overflow="auto">
-                    {curPinIndex !== -1 ? 
-                        <Box fontStyle="italic" fontSize={18}>
+            <ColorLibPaper elevation={1}>
+                <Typography variant="h4" style={{ textTransform: 'capitalize' }}>
+                    {userMode}
+                </Typography>
+                {curPinIndex !== -1 ?
+                    <Box fontStyle="italic">
+                        <Typography>
                             The session was pinned at {formatTime(pins.map(pin => pin.pinTime)[curPinIndex])}
-                        </Box>
+                        </Typography>
+                    </Box>
                     : null}
-                    <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium"> 
-                        Personal Notes
-                    </Box>
-                    <ColorLibTextField
-                        id="outlined-secondary"
-                        fullWidth
-                        variant="outlined"
-                        multiline
-                        rows={3}
-                        margin="normal"
-                        value = {curNoteInfo}
-                        inputRef={noteValueRef}  
-                        onChange = {() =>{setCurNoteInfo(noteValueRef.current.value); console.log("cur: "+ curNoteInfo);}}
-                    />
-                    <Box my={1} fontStyle="italic" fontSize={18}> To share with your peer:</Box>
-                    <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" m={2}> 
-                        What is your perspective of what happened at this pin? 
-                    </Box>
-                    <ColorLibTextField
-                        id="outlined-secondary"
-                        fullWidth
-                        variant="outlined"
-                        multiline
-                        rows={3}
-                        margin="normal"                        
-                        value = {curPerspectiveInfo}
-                        inputRef={perspectiveValueRef}
-                        onChange = {() => setCurPerspectiveInfo(perspectiveValueRef.current.value)}
-                    />
-                    <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" m={2}> 
-                        What would you categorize this pin as?
-                    </Box>       
-                    <Box align="left" m = {3}>          
-                        <ToggleButtonGroup
-                            value={pinType}
-                            exclusive
-                            onChange={handlePinType}
-                            size = "large"
-                        >
-                            <ToggleButton value="strength" selected = {pinType === "strength"}>
-                                Strength
-                            </ToggleButton>
-                            <ToggleButton value="opportunity" selected = {pinType === "opportunity"}>
-                                Opportunity
-                            </ToggleButton>
-                        </ToggleButtonGroup>
-                    </Box>   
-                    <MISkillsSheet pinType = {pinType}/>
-                    <ColorLibTextField
-                        id="outlined-secondary"
-                        fullWidth
-                        variant="outlined"
-                        multiline
-                        rowsMax={2}
-                        margin="normal"                        
-                        value = {curSkillInfo}
-                        inputRef={skillValueRef}
-                        onChange = {() => setCurSkillInfo(skillValueRef.current.value)}
-                    />
+                {/* <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium">
+                    Personal Notes
+                </Box> */}
+                <ColorLibTextField
+                    id="outlined-secondary"
+                    fullWidth
+                    variant="outlined"
+                    multiline
+                    rows={3}
+                    margin="normal"
+                    label="Personal notes..."
+                    value={curNoteInfo}
+                    inputRef={noteValueRef}
+                    onChange={() => { setCurNoteInfo(noteValueRef.current.value); console.log("cur: " + curNoteInfo); }}
+                />
+                <Box fontStyle="italic" marginTop="30px"> 
+                    <Typography variant = "h3">
+                        To share with your peer:
+                    </Typography>
                 </Box>
-            </Paper>
-
+                <Box textAlign="left" >
+                    <Typography>
+                        What is your perspective of what happened at this pin?
+                    </Typography>
+                </Box>
+                <ColorLibTextField
+                    id="outlined-secondary"
+                    fullWidth
+                    variant="outlined"
+                    multiline
+                    rows={3}
+                    margin="normal"
+                    value={curPerspectiveInfo}
+                    inputRef={perspectiveValueRef}
+                    onChange={() => setCurPerspectiveInfo(perspectiveValueRef.current.value)}
+                />
+                <Box textAlign="left" >
+                    <Typography>
+                        What would you categorize this pin as?
+                    </Typography>
+                </Box>
+                <Box align="left">
+                    <ToggleButtonGroup
+                        className={classes.toggleGroup}
+                        value={pinType}
+                        exclusive
+                        onChange={handlePinType}
+                        size="large"
+                    >
+                        <ToggleButton value="strength" selected={pinType === "strength"}>
+                            Strength
+                        </ToggleButton>
+                        <ToggleButton value="opportunity" selected={pinType === "opportunity"}>
+                            Opportunity
+                        </ToggleButton>
+                    </ToggleButtonGroup>
+                </Box>
+                <MISkillsSheet pinType={pinType} />
+                <ColorLibTextField
+                    id="outlined-secondary"
+                    fullWidth
+                    variant="outlined"
+                    multiline
+                    rowsMax={2}
+                    margin="normal"
+                    value={curSkillInfo}
+                    inputRef={skillValueRef}
+                    onChange={() => setCurSkillInfo(skillValueRef.current.value)}
+                />
+            </ColorLibPaper>
         </Grid>
     );
 };

--- a/src/components/Transcription.js
+++ b/src/components/Transcription.js
@@ -1,5 +1,6 @@
 import React, {useEffect, useState} from 'react';
-import { Typography, Box, Grid, Paper } from '@material-ui/core';
+import { Typography, Box, Grid } from '@material-ui/core';
+import ColorLibPaper from './layout/ColorLibComponents/ColorLibPaper';
 import { firebase } from "../hooks/firebase";
 import { useSessionValue } from '../context';
 
@@ -68,16 +69,16 @@ const Transcription = () => {
 
     return (
         <Grid item xs={12} sm={4}>
-            <Paper>
-                <Box m={2} height={600} overflow="auto">
-                    <Box fontSize={20} fontStyle="Normal" fontWeight="fontWeightBold">
+            <ColorLibPaper>
+                <Box fontStyle="italic">
+                    <Typography>
                         Transcript
-                    </Box>
-                    <Typography component="div" >
-                        {renderTranscript()}
                     </Typography>
                 </Box>
-            </Paper>
+                <Typography component="div" >
+                    {renderTranscript()}
+                </Typography>
+            </ColorLibPaper>
 
         </Grid>
     );

--- a/src/components/layout/ColorLibComponents/ColorLibPaper.jsx
+++ b/src/components/layout/ColorLibComponents/ColorLibPaper.jsx
@@ -12,6 +12,13 @@ const ColorLibPaper = withStyles((theme) => ({
     boxShadow: 'none',
     padding: '50px 80px',
   },
+  elevation1: {
+    // For Transcript, Notetaking, and ..
+    backgroundColor: theme.palette.teal.lighter,
+    borderRadius: '4px',
+    boxShadow: 'none',
+    padding: '30px',
+  },
   elevation9: {
     // For Refresher Page final answer preview
     borderRadius: '10px',

--- a/src/components/layout/ColorLibComponents/ColorLibTextField.jsx
+++ b/src/components/layout/ColorLibComponents/ColorLibTextField.jsx
@@ -11,6 +11,7 @@ const CustomizedTextField = withStyles((theme) => ({
       color: theme.palette.gray.main,
     },
     '& .MuiOutlinedInput-root': {
+      background: 'white',
       borderRadius: '5px',
       '& fieldset': {
         borderColor: theme.palette.teal.light,
@@ -23,9 +24,12 @@ const CustomizedTextField = withStyles((theme) => ({
       '&.Mui-focused fieldset': {
         borderColor: theme.palette.teal.main,
         borderWidth: '1.5px',
-      }
-    }
-  }
+      },
+    },
+    '&.MuiFormControl-marginNormal': {
+      margin: '8px 0px 16px 0px'
+    },
+  },
 }))(TextField);
 
 const ColorLibTextField = (props) => {

--- a/src/components/layout/ColorLibComponents/ColorLibTextField.jsx
+++ b/src/components/layout/ColorLibComponents/ColorLibTextField.jsx
@@ -10,6 +10,22 @@ const CustomizedTextField = withStyles((theme) => ({
     '& .MuiInputBase-input': {
       color: theme.palette.gray.main,
     },
+    '& .MuiInputBase-root.Mui-disabled': {
+      opacity: '50%',
+      borderColor: '1px solid ' + theme.palette.teal.light,
+      '& fieldset': {
+        borderColor: theme.palette.teal.light,
+        borderWidth: '1.5px',
+      },
+      '&:hover fieldset': {
+        borderColor: theme.palette.teal.light,
+        borderWidth: '1.5px',
+      },
+      '&.Mui-focused fieldset': {
+        borderColor: theme.palette.teal.light,
+        borderWidth: '1.5px',
+      },
+    },
     '& .MuiOutlinedInput-root': {
       background: 'white',
       borderRadius: '5px',

--- a/src/components/layout/ColorLibComponents/ColorLibTextField.jsx
+++ b/src/components/layout/ColorLibComponents/ColorLibTextField.jsx
@@ -1,46 +1,36 @@
 import { makeStyles, withStyles } from '@material-ui/core/styles';
 
 import TextField from '@material-ui/core/TextField';
-
-// const ColorLibTextField = withStyles((theme) => ({
-//   root: {
-//     marginTop: '8px',
-//     '&.MuiInputLabel-root': {
-//       color: theme.palette.teal.main,
-//     },
-//   }
-// }))(TextField);
-
-const ColorLibTextField = (props) => {
-  const CustomizedTextField = withStyles((theme) => ({
-    root: {
-      '& .MuiInputLabel-outlined': {
-        color: theme.palette.gray.main,
-        opacity: '60%',
+const CustomizedTextField = withStyles((theme) => ({
+  root: {
+    '& .MuiInputLabel-outlined': {
+      color: theme.palette.gray.main,
+      opacity: '60%',
+    },
+    '& .MuiInputBase-input': {
+      color: theme.palette.gray.main,
+    },
+    '& .MuiOutlinedInput-root': {
+      borderRadius: '5px',
+      '& fieldset': {
+        borderColor: theme.palette.teal.light,
+        borderWidth: '1.5px',
       },
-      '& .MuiInputBase-input': {
-        color: theme.palette.gray.main,
+      '&:hover fieldset': {
+        borderColor: theme.palette.teal.main,
+        borderWidth: '1.5px',
       },
-      '& .MuiOutlinedInput-root': {
-        borderRadius: '5px',
-        '& fieldset': {
-          borderColor: theme.palette.teal.light,
-          borderWidth: '1.5px',
-        },
-        '&:hover fieldset': {
-          borderColor: theme.palette.teal.main,
-          borderWidth: '1.5px',
-        },
-        '&.Mui-focused fieldset': {
-          borderColor: theme.palette.teal.main,
-          borderWidth: '1.5px',
-        }
+      '&.Mui-focused fieldset': {
+        borderColor: theme.palette.teal.main,
+        borderWidth: '1.5px',
       }
     }
-  }))(TextField);
+  }
+}))(TextField);
 
+const ColorLibTextField = (props) => {
   return (
-    <CustomizedTextField 
+    <CustomizedTextField
       {...props}
       label={props.label ?? "Type a response..."}
     />

--- a/src/components/layout/MISkillsSheet.jsx
+++ b/src/components/layout/MISkillsSheet.jsx
@@ -50,13 +50,14 @@ const MISkillsSheet = ({pinType}) => {
         <div>
             {pinType === undefined ? null : 
             <div>
-            <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" m={1}> 
-                What   
-                <Link href="#" onClick={() => {handleClickOpen()}}>
-                    {" MI skills "}
-                </Link>
-                
-                {pinType === "strength" ? str1 : str2}
+            <Box textAlign="left">
+                <Typography>
+                    What   
+                    <Link href="#" onClick={() => {handleClickOpen()}}>
+                        {" MI skills "}
+                    </Link>
+                    {pinType === "strength" ? str1 : str2}
+                </Typography> 
             </Box>   
             <Dialog onClose={handleClose} open={skillInfoOpened}>
                 <DialogTitle onClose={handleClose} align="center">

--- a/src/components/layout/Modules.jsx
+++ b/src/components/layout/Modules.jsx
@@ -15,7 +15,7 @@ import { usePins } from '../../hooks/index';
 function getStepContent(step) {
     switch (step) {
       case 0:
-        return <Refresher />
+        return <Refresher />;
       case 1:
         return <PracticeSession />;
       case 2:

--- a/src/components/layout/PracticeSession.jsx
+++ b/src/components/layout/PracticeSession.jsx
@@ -1,5 +1,5 @@
 import { Box } from '@material-ui/core';
-import React, {useState, useEffect} from 'react';
+import React, { useState, useEffect } from 'react';
 import Intro from "./PracticeSession/Intro.jsx"
 import Narrative from "./PracticeSession/Narrative.jsx"
 import Session from "./PracticeSession/Session.jsx"
@@ -9,65 +9,65 @@ import ColorLibButton, { ColorLibNextButton } from './ColorLibComponents/ColorLi
 
 
 function getConditionalContent(page) {
-    switch (page) {
-      case 0:
-        return <Intro />
-      case 1:
-        return <Narrative />;
-      case 2:
-        return <Session />;
-      default:
-        return <div>Unknown</div>;
-    }
+  switch (page) {
+    case 0:
+      return <Intro />
+    case 1:
+      return <Narrative />;
+    case 2:
+      return <Session />;
+    default:
+      return <div>Unknown</div>;
+  }
 }
 
 function getConditionalButton(page, setPage, setButton) {
   const handleButton = () => {
-    setPage(page+1);
-    if(page == 2) setButton(true);
-}
-    switch (page) {
-      case 0:
-        return (
-          <div>
-            <Box align='center' m = {2} mb = {20}>
-              <ColorLibNextButton 
-                variant='contained' 
-                size='medium' 
-                onClick={() => handleButton()}
-              >
-                Review Information on Client
-              </ColorLibNextButton>
-            </Box>
-          </div>
-        );
-      case 1:
-        return (
-          <div>
-            <Box align='center' m = {2} mb = {20}> 
-              <ColorLibButton variant='contained' size='medium' onClick={() => handleButton()}>
-                Begin Live Session
-              </ColorLibButton>
-            </Box>
-          </div>
-        );
-      case 2:
-        return ;
-      default:
-        return <div>Unknown</div>;
-    }
+    setPage(page + 1);
+    if (page == 2) setButton(true);
+  }
+  switch (page) {
+    case 0:
+      return (
+        <div>
+          <Box align='center' m={2} mb={20}>
+            <ColorLibNextButton
+              variant='contained'
+              size='medium'
+              onClick={() => handleButton()}
+            >
+              Review Information on Client
+            </ColorLibNextButton>
+          </Box>
+        </div>
+      );
+    case 1:
+      return (
+        <div>
+          <Box align='center' m={2} mb={20}>
+            <ColorLibButton variant='contained' size='medium' onClick={() => handleButton()}>
+              Begin Live Session
+            </ColorLibButton>
+          </Box>
+        </div>
+      );
+    case 2:
+      return;
+    default:
+      return <div>Unknown</div>;
+  }
 }
 
 const PracticeSession = () => {
 
-    const {setButton} = useSessionValue();
-    const [page, setPage] = useState(0);
-    return (  
-        <div>
-            {getConditionalContent(page)}
-            {getConditionalButton(page, setPage, setButton)}
-        </div>
-    );
+  const { setButton } = useSessionValue();
+  const [page, setPage] = useState(0);
+  return (
+    <div>
+      {getConditionalContent(page)}
+      {getConditionalButton(page, setPage, setButton)}
+    </div>
+  );
 }
 
 

--- a/src/components/layout/PracticeSession/Intro.jsx
+++ b/src/components/layout/PracticeSession/Intro.jsx
@@ -11,48 +11,48 @@ import Box from '@material-ui/core/Box';
 
 
 const useStyles = makeStyles({
-    table: {
-      width: 600,
-    },
-  });
+  table: {
+    width: 600,
+  },
+});
 
 
 function createData(name, role, fat, carbs, protein) {
-    return { name, role, fat, carbs, protein };
-  }
-  
-  const rows = [
-    createData('Your role', 'Therapist', 6.0, 24, 4.0),
-    createData('Your peers role', 'Client', 237, 9.0, 37, 4.3),
-    createData('Your goal', 'Build rapport and analyze the client’s situation', 262, 16.0, 24, 6.0),
-  ];
-  
+  return { name, role, fat, carbs, protein };
+}
+
+const rows = [
+  createData('Your role', 'Therapist', 6.0, 24, 4.0),
+  createData('Your peers role', 'Client', 237, 9.0, 37, 4.3),
+  createData('Your goal', 'Build rapport and analyze the client’s situation', 262, 16.0, 24, 6.0),
+];
+
 const Intro = () => {
-    const classes = useStyles();
-    return (  
-      <div>
-        <Box align="center" m = {2}>
-             <h1>Now, it’s time to step into the practice session and practice using open-ended questions.</h1>
-            <TableContainer>
-      <Table className={classes.table} aria-label="simple table">
-        
-        <TableBody>
-          {rows.map((row) => (
-            <TableRow key={row.name}>
-              <TableCell component="th" scope="row">
-              <Box fontWeight="fontWeightBold">{row.name}</Box>
-              </TableCell>
-              <TableCell component="th" scope="row">
-                {row.role}
-              </TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    </TableContainer>  
-    </Box>  
-        </div>
-    );
+  const classes = useStyles();
+  return (
+    <div>
+      <Box align="center" m={2}>
+        <h1>Now, it’s time to step into the practice session and practice using open-ended questions.</h1>
+        <TableContainer>
+          <Table className={classes.table} aria-label="simple table">
+
+            <TableBody>
+              {rows.map((row) => (
+                <TableRow key={row.name}>
+                  <TableCell component="th" scope="row">
+                    <Box fontWeight="fontWeightBold">{row.name}</Box>
+                  </TableCell>
+                  <TableCell component="th" scope="row">
+                    {row.role}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Box>
+    </div>
+  );
 }
 
 

--- a/src/components/layout/PracticeSession/Intro.jsx
+++ b/src/components/layout/PracticeSession/Intro.jsx
@@ -1,17 +1,17 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
 import TableContainer from '@material-ui/core/TableContainer';
-import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
-import Paper from '@material-ui/core/Paper';
-import Box from '@material-ui/core/Box';
+import Typography from '@material-ui/core/Typography';
 
 
 const useStyles = makeStyles({
   table: {
+    marginTop: '20px',
     width: 600,
   },
 });
@@ -31,8 +31,10 @@ const Intro = () => {
   const classes = useStyles();
   return (
     <div>
-      <Box align="center" m={2}>
-        <h1>Now, it’s time to step into the practice session and practice using open-ended questions.</h1>
+      <Box align="center" m={6}>
+        <Typography variant="h4" style={{textAlign: "left", width: "50%"}}>
+          Now, it’s time to step into the practice session and practice using open-ended questions.
+        </Typography>
         <TableContainer>
           <Table className={classes.table} aria-label="simple table">
 

--- a/src/components/layout/PracticeSession/Narrative.jsx
+++ b/src/components/layout/PracticeSession/Narrative.jsx
@@ -6,6 +6,7 @@ import TableCell from '@material-ui/core/TableCell';
 import TableContainer from '@material-ui/core/TableContainer';
 import TableRow from '@material-ui/core/TableRow';
 import Box from '@material-ui/core/Box';
+import { Typography } from '@material-ui/core';
 
 
 const useStyles = makeStyles({
@@ -30,7 +31,9 @@ const Narrative = () => {
   return (
     <div>
       <Box align="center" m={2}>
-        <h1> Client Information </h1>
+        <Typography variant="h4">
+          Client Information
+        </Typography>
         <TableContainer>
           <Table className={classes.table} aria-label="simple table">
 

--- a/src/components/layout/PracticeSession/Narrative.jsx
+++ b/src/components/layout/PracticeSession/Narrative.jsx
@@ -4,55 +4,53 @@ import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
 import TableContainer from '@material-ui/core/TableContainer';
-import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
-import Paper from '@material-ui/core/Paper';
 import Box from '@material-ui/core/Box';
 
 
 const useStyles = makeStyles({
-    table: {
-      width: 600,
-    },
-  });
+  table: {
+    width: 600,
+  },
+});
 
 
 function createData(name, role, fat, carbs, protein) {
-    return { name, role, fat, carbs, protein };
-  }
-  
-  const rows = [
-    createData('Full Name', 'Julia Rogers', 6.0, 24, 4.0),
-    createData('Reason for appointment', 'I’m going through a hard time and I’m not sure what to do.', 262, 16.0, 24, 6.0),
-  ];
+  return { name, role, fat, carbs, protein };
+}
 
-  
+const rows = [
+  createData('Full Name', 'Julia Rogers', 6.0, 24, 4.0),
+  createData('Reason for appointment', 'I’m going through a hard time and I’m not sure what to do.', 262, 16.0, 24, 6.0),
+];
+
+
 const Narrative = () => {
-    const classes = useStyles();
-    return (  
-        <div>
-            <Box align="center" m = {2}>
-            <h1> Client Information </h1>
-            <TableContainer>
-      <Table className={classes.table} aria-label="simple table">
-        
-        <TableBody>
-          {rows.map((row) => (
-            <TableRow key={row.name}>
-              <TableCell component="th" scope="row">
-              <Box fontWeight="fontWeightBold">{row.name}</Box>
-              </TableCell>
-              <TableCell component="th" scope="row">
-                {row.role}
-              </TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    </TableContainer>  
-            </Box>
-        </div>
-    );
+  const classes = useStyles();
+  return (
+    <div>
+      <Box align="center" m={2}>
+        <h1> Client Information </h1>
+        <TableContainer>
+          <Table className={classes.table} aria-label="simple table">
+
+            <TableBody>
+              {rows.map((row) => (
+                <TableRow key={row.name}>
+                  <TableCell component="th" scope="row">
+                    <Box fontWeight="fontWeightBold">{row.name}</Box>
+                  </TableCell>
+                  <TableCell component="th" scope="row">
+                    {row.role}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Box>
+    </div>
+  );
 }
 
 

--- a/src/components/layout/Refresher.jsx
+++ b/src/components/layout/Refresher.jsx
@@ -14,6 +14,7 @@ const Refresher = () => {
   const { curActiveStep: activeStep, setCurActiveStep: setActiveStep } = useActiveStepValue();
   const { sessionID } = useSessionValue();
   const [submitted, setSubmitted] = useState(false);
+  const [submittedAnswers, setSubmittedAnswers] = useState(['', '', '', '']);
   const [question1Ans, setQuestion1Ans] = useState('');
   const [question2Ans, setQuestion2Ans] = useState('');
   const [openEndedQuesAns, setOpenEndedQuesAns] = useState(['', '', '', '']);
@@ -76,10 +77,26 @@ const Refresher = () => {
     });
   }
 
+  const fetchCurAnswers = async () => {
+    const docRef = await firebase.firestore().collection("refresher").doc(sessionID).collection("users").doc(userID);
+    const curAnswers = 
+      await docRef.get().then((doc) => {
+        if (doc.exists) {
+          return [doc.data()['q1'], doc.data()['q2'], doc.data()['q3'], doc.data()['q4']];
+        } else {
+          console.log("No such document!");
+        }
+      }).catch((error) => {
+        console.log("Error getting document:", error);
+      })
+    setSubmittedAnswers(curAnswers);
+  }
+
   const handleSubmit = async () => {
     makeSessionDoc();
     makeRefresherDoc();
     setSubmitted(true);
+    fetchCurAnswers();
   }
 
   /* TODO: The 'submittedResponse's are just placeholders for now.
@@ -150,7 +167,7 @@ const Refresher = () => {
                 Your Response
               </Typography>
               <Typography variant="body2">
-                {openEndedQuesAns[index]}
+                {submittedAnswers[index]}
               </Typography>
             </ColorLibPaper>
           </Grid>

--- a/src/components/layout/Refresher.jsx
+++ b/src/components/layout/Refresher.jsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, { useState } from 'react';
 import { Box, Container, Grid } from '@material-ui/core';
 import { Fragment } from 'react';
 import { useUserModeValue, useActiveStepValue, useSessionValue } from '../../context';
@@ -11,45 +11,52 @@ import { firebase } from "../../hooks/firebase";
 
 
 const Refresher = () => {
-  const {curActiveStep: activeStep, setCurActiveStep: setActiveStep} = useActiveStepValue();
-  const {sessionID} = useSessionValue();
+  const { curActiveStep: activeStep, setCurActiveStep: setActiveStep } = useActiveStepValue();
+  const { sessionID } = useSessionValue();
   const [submitted, setSubmitted] = useState(false);
-	const [question1Ans, setQuestion1Ans] = useState('');
-	const [question2Ans, setQuestion2Ans] = useState('');
+  const [question1Ans, setQuestion1Ans] = useState('');
+  const [question2Ans, setQuestion2Ans] = useState('');
+  const [openEndedQuesAns, setOpenEndedQuesAns] = useState(['', '', '', '']);
 
-	const {userMode, setUserMode, userID, setUserID} = useUserModeValue();
+  const { userMode, setUserMode, userID, setUserID } = useUserModeValue();
 
-	const handleUserMode = (event, newMode) => {
-    const caller = 'tI2fK1Py7Ibsznp3MDz4';  
+  const handleUserMode = (event, newMode) => {
+    const caller = 'tI2fK1Py7Ibsznp3MDz4';
     const callee = '6AT1Se8aU93MPGXZ5miK';
-		if (newMode !== null) {
-			setUserMode(newMode);
-      if(newMode == 'caller'){
+    if (newMode !== null) {
+      setUserMode(newMode);
+      if (newMode == 'caller') {
         setUserID(caller);
       } else {
         setUserID(callee);
       }
-		}
-	};
+    }
+  };
 
-	const handleQuestion1 = (event, newAns) => {
-	  if (newAns !== null) {
-		setQuestion1Ans(newAns);
-	  }
-	};
+  const handleQuestion1 = (event, newAns) => {
+    if (newAns !== null) {
+      setQuestion1Ans(newAns);
+    }
+  };
 
-	const handleQuestion2 = (event, newAns) => {
-		if (newAns !== null) {
-		  setQuestion2Ans(newAns);
-		}
-	  };
+  const handleQuestion2 = (event, newAns) => {
+    if (newAns !== null) {
+      setQuestion2Ans(newAns);
+    }
+  };
 
-	const handleNext = () => {
-		setActiveStep((prevActiveStep) => prevActiveStep + 1);
+  const handleOpenEndedQues = (answer, index) => {
+    let newAnswers = [...openEndedQuesAns];
+    newAnswers[index] = answer;
+    setOpenEndedQuesAns(newAnswers);
+  }
+
+  const handleNext = () => {
+    setActiveStep((prevActiveStep) => prevActiveStep + 1);
   };
 
   const makeSessionDoc = async () => {
-    const caller = 'tI2fK1Py7Ibsznp3MDz4';  
+    const caller = 'tI2fK1Py7Ibsznp3MDz4';
     const callee = '6AT1Se8aU93MPGXZ5miK';
     await firebase.firestore().collection("sessions").doc(sessionID).set({
       callee_id: callee,
@@ -62,19 +69,19 @@ const Refresher = () => {
 
   const makeRefresherDoc = async () => {
     await firebase.firestore().collection("refresher").doc(sessionID).collection("users").doc(userID).set({
-        q1: openEndedQuestions[0].submittedResponse,
-        q2: openEndedQuestions[1].submittedResponse,
-        q3: openEndedQuestions[2].submittedResponse,
-        q4: openEndedQuestions[3].submittedResponse
+      q1: openEndedQuesAns[0],
+      q2: openEndedQuesAns[1],
+      q3: openEndedQuesAns[2],
+      q4: openEndedQuesAns[3],
     });
   }
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     makeSessionDoc();
     makeRefresherDoc();
     setSubmitted(true);
   }
-  
+
   /* TODO: The 'submittedResponse's are just placeholders for now.
    * After the database is set up, then should be replaced with what was sent to the database. */
   const openEndedQuestions = [
@@ -83,7 +90,7 @@ const Refresher = () => {
       description: "Convert the closed question to open-ended...",
       submittedResponse: "How is your day going?",
       sampleResponse: "What has been good in your day so far?",
-    }, 
+    },
     {
       question: "How much do you drink on a typical drinking occasion?",
       description: "Convert the closed question to open-ended...",
@@ -104,7 +111,7 @@ const Refresher = () => {
     }
   ]
 
-  const getOpenEndQuestionSet = (question, submitted) => {
+  const getOpenEndQuestionSet = (question, index, submitted) => {
     let response = <div />;
     if (!submitted) {
       response = (
@@ -115,13 +122,15 @@ const Refresher = () => {
           variant="outlined"
           multiline
           rowsMax={2}
-           margin="normal"
+          margin="normal"
+          value={openEndedQuesAns[index]}
+          onChange={event => handleOpenEndedQues(event.target.value, index)}
         />
       );
     } else {
       response = (
-        <Grid 
-          container 
+        <Grid
+          container
           direction="row"
           justifyContent="center"
           style={{
@@ -130,8 +139,8 @@ const Refresher = () => {
           }}
         >
           <Grid item xs={6}>
-            <ColorLibPaper 
-              elevation={9} 
+            <ColorLibPaper
+              elevation={9}
               style={{
                 height: 'calc(100% - 16px)',
                 marginRight: '17px',
@@ -141,13 +150,13 @@ const Refresher = () => {
                 Your Response
               </Typography>
               <Typography variant="body2">
-                {question.submittedResponse}
+                {openEndedQuesAns[index]}
               </Typography>
             </ColorLibPaper>
           </Grid>
           <Grid item xs={6}>
-            <ColorLibPaper 
-              elevation={9} 
+            <ColorLibPaper
+              elevation={9}
               style={{
                 height: 'calc(100% - 16px)',
                 marginLeft: '17px',
@@ -166,7 +175,7 @@ const Refresher = () => {
     }
     return (
       <Fragment>
-        <Typography variant='body1' style={{marginTop: '10px'}}> 
+        <Typography variant='body1' style={{ marginTop: '10px' }}>
           {question.question}
         </Typography>
         {response}
@@ -181,9 +190,9 @@ const Refresher = () => {
   const getButton = (submitted, isValid) => {
     if (submitted) {
       return (
-        <ColorLibButton 
+        <ColorLibButton
           variant='contained'
-          size='medium' 
+          size='medium'
           onClick={handleNext}
         >
           Prepare for Live Session
@@ -191,8 +200,8 @@ const Refresher = () => {
       );
     } else {
       return (
-        <ColorLibButton 
-          size='medium' 
+        <ColorLibButton
+          size='medium'
           variant={!isValid ? 'outlined' : 'contained'}
           disabled={!isValid ? true : false}
           onClick={handleSubmit}
@@ -203,10 +212,10 @@ const Refresher = () => {
     }
   };
 
-	return (
-		<Fragment>
+  return (
+    <Fragment>
       <Container maxWidth='md'>
-        <Box align="left" m = {2}> 
+        <Box align="left" m={2}>
           <ColorLibToggleButtonGroup
             value={userMode}
             exclusive
@@ -222,13 +231,13 @@ const Refresher = () => {
           </ColorLibToggleButtonGroup>
         </Box>
         <Typography variant='h2'>
-          {submitted 
-          ? "Complete the exercises to unlock today’s session!" 
-          : "Review the following before we begin the practice session."}
+          {submitted
+            ? "Complete the exercises to unlock today’s session!"
+            : "Review the following before we begin the practice session."}
         </Typography>
-        <Grid container style={{marginTop: '20px'}}>
+        <Grid container style={{ marginTop: '20px' }}>
           <Grid item xs={9}>
-            <Typography variant='body1' style={{marginRight: '12px'}}>
+            <Typography variant='body1' style={{ marginRight: '12px' }}>
               Closed questions are bad.
             </Typography>
           </Grid>
@@ -247,20 +256,20 @@ const Refresher = () => {
             </ColorLibToggleButtonGroup>
           </Grid>
           {!submitted ? null :
-          <ColorLibPaper elevation={9} style={{margin:'15px 0px'}}>
-            <Typography variant="body2">
-              {question1Ans === "false" ? "Correct!" : "Sorry, try again."} Closed questions are not “bad.” They simply are limited as a tool, so we try to avoid using them in favor of open-ended questions. However, there are situations in which closed questions are desirable. In general, the aim is to ask more open-ended than closed questions.
-            </Typography>
-          </ColorLibPaper>
+            <ColorLibPaper elevation={9} style={{ margin: '15px 0px' }}>
+              <Typography variant="body2">
+                {question1Ans === "false" ? "Correct!" : "Sorry, try again."} Closed questions are not “bad.” They simply are limited as a tool, so we try to avoid using them in favor of open-ended questions. However, there are situations in which closed questions are desirable. In general, the aim is to ask more open-ended than closed questions.
+              </Typography>
+            </ColorLibPaper>
           }
         </Grid>
-        <Grid container style={{marginTop: '20px'}}>
+        <Grid container style={{ marginTop: '20px' }}>
           <Grid item xs={9}>
-            <Typography variant='body1' style={{marginRight: '12px'}}> 
+            <Typography variant='body1' style={{ marginRight: '12px' }}>
               We use reflections to help clients not only see what they've told us, but to also help organize and understand their experience.
             </Typography>
           </Grid>
-          <Grid item xs={3}>        
+          <Grid item xs={3}>
             <ColorLibToggleButtonGroup
               value={question2Ans}
               exclusive
@@ -275,27 +284,27 @@ const Refresher = () => {
             </ColorLibToggleButtonGroup>
           </Grid>
           {!submitted ? null :
-          <ColorLibPaper elevation={9} style={{margin:'15px 0px'}}>
-            <Typography variant="body2">
-              {question2Ans === "true" ? "Correct!" : "Sorry, try again."} If we simply hold up the mirror, then we aren’t helping clients become unstuck. In addition to helping clients hear again what they’re told us, we also selectively attend to certain elements and not to others and then present that information back in a manner that helps them attain greater understanding of their situation
-            </Typography>
-          </ColorLibPaper>}
+            <ColorLibPaper elevation={9} style={{ margin: '15px 0px' }}>
+              <Typography variant="body2">
+                {question2Ans === "true" ? "Correct!" : "Sorry, try again."} If we simply hold up the mirror, then we aren’t helping clients become unstuck. In addition to helping clients hear again what they’re told us, we also selectively attend to certain elements and not to others and then present that information back in a manner that helps them attain greater understanding of their situation
+              </Typography>
+            </ColorLibPaper>}
         </Grid>
-        <Typography variant='h4' style={{marginTop: '50px'}}>
+        <Typography variant='h4' style={{ marginTop: '50px' }}>
           Practicing Open-ended Questions
         </Typography>
-        {openEndedQuestions.map(ques => getOpenEndQuestionSet(ques, submitted))}
+        {openEndedQuestions.map((ques, index) => getOpenEndQuestionSet(ques, index, submitted))}
       </Container>
-      
-			<div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '50px 0px'}}>
+
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '50px 0px' }}>
         {getButton(
-          submitted, 
+          submitted,
           checkValidness(question1Ans, question2Ans)
         )}
-			</div>
-			
-		</Fragment>
-	);
+      </div>
+
+    </Fragment>
+  );
 }
- 
+
 export default Refresher;

--- a/src/components/layout/Refresher.jsx
+++ b/src/components/layout/Refresher.jsx
@@ -174,7 +174,7 @@ const Refresher = () => {
       )
     }
     return (
-      <Fragment>
+      <Fragment key={`open-ended-${index}`}>
         <Typography variant='body1' style={{ marginTop: '10px' }}>
           {question.question}
         </Typography>


### PR DESCRIPTION
### Description
- A general update to match each page's style and layout with the Figma design.
- Fixes the weird cursor issue with TextField.
- Replaces the placeholders on the Refresher page with actual states so that the user input is now sent to our database.

### Changes
- This is how a complete tour now looks like:

https://user-images.githubusercontent.com/55717622/136707786-1e90b105-c4f1-44bc-9ec5-9ea50ddb0497.mov


### Remaining issues
- Many pages are still not connected to the database yet, especially the pages using useRefs. The Discussion page currently shows a seemingly unrelated string for the personal notes section because it was previously stored in the databased and not updated with the new user submission.