### PR TITLE
Preview and disable Audio/Video; Pin Navigation buttons; Scrollable Transcript

### DIFF
--- a/src/components/AudioReview.js
+++ b/src/components/AudioReview.js
@@ -86,17 +86,14 @@ const AudioReview = ({curPinIndex, setCurPinIndex, prevPinIndex, setPrevPinIndex
             callerPinPerspective: '',
             callerPinCategory: '',
             callerPinSkill: '',
-            callerPinGoal: '',
-            callerPinStrength: '',
-            callerPinOpportunity: '',
             calleePinNote: '',
             calleePinPerspective: '',
             calleePinCategory: '',
             calleePinSkill: '',
-            calleePinGoal: '',
-            calleePinStrength: '',
-            calleePinOpportunity: '',
-            pinEfficacy: ''
+            pinEfficacy: '',
+            pinGoal: '',
+            pinStrength: '',
+            pinOpportunity: '',
         }; 
 
         //now correctly add the pin into the array to maintain sortedness

--- a/src/components/DiscussionVideo.js
+++ b/src/components/DiscussionVideo.js
@@ -133,8 +133,8 @@ function VideoChatComponent(props) {
         pinTime: curTime,
         // pinInfos: {"pinNote": "", "pinPerspective": "", "pinCategory": "", "pinSkill": ""},
         sessionID: MiTrainingSessionID,
-        callerPinInfos: {"pinNote": "", "pinPerspective": "", "pinCategory": "", "pinSkill": "", "pinGoal":"", "pinStrength":"", "pinOpportunity": ""},
-        calleePinInfos: {"pinNote": "", "pinPerspective": "", "pinCategory": "", "pinSkill": "", "pinGoal":"", "pinStrength":"", "pinOpportunity": ""},
+        callerPinInfos: {"pinNote": "", "pinPerspective": "", "pinCategory": "", "pinSkill": ""},
+        calleePinInfos: {"pinNote": "", "pinPerspective": "", "pinCategory": "", "pinSkill": ""},
     })        
     .then( () => {
         setPins([...pins, ]);

--- a/src/components/DissResponse.js
+++ b/src/components/DissResponse.js
@@ -36,8 +36,11 @@ const DissResponse = ({ curPinIndex, prevPinIndex }) => {
 
     const classes = useStyles();
 
-    //creating a refernce for TextField Component
-    const noteValueRef = useRef('')
+    //creating a refernce for TextField Components
+    const efficacyValueRef = useRef('')
+    const goalValueRef = useRef('')
+    const strengthValueRef = useRef('')
+    const opportunityValueRef = useRef('')
 
     //get sessionID
     const { sessionID } = useSessionValue();
@@ -56,25 +59,24 @@ const DissResponse = ({ curPinIndex, prevPinIndex }) => {
     const [pinType1, setPinType1] = useState('');
     const [pinType2, setPinType2] = useState('');
 
-
     const [curSkillInfo1, setCurSkillInfo1] = useState('');
     const [curSkillInfo2, setCurSkillInfo2] = useState('');
 
-    const [curGoalInfo1, setCurGoalInfo1] = useState('');
-    const [curGoalInfo2, setCurGoalInfo2] = useState('');
-
-    const [curStrengthInfo1, setCurStrengthInfo1] = useState('');
-    const [curStrengthInfo2, setCurStrengthInfo2] = useState('');
-
-    const [curOpportunityInfo1, setCurOpportunityInfo1] = useState('');
-    const [curOpportunityInfo2, setCurOpportunityInfo2] = useState('');
-
     const [curEfficacyInfo, setCurEfficacyInfo] = useState(pins[curPinIndex].pinEfficacy);
+    const [curGoalInfo, setCurGoalInfo] = useState(pins[curPinIndex].pinGoal);
+    const [curStrengthInfo, setCurStrengthInfo] = useState(pins[curPinIndex].pinStrength);
+    const [curOpporunityInfo, setCurOpportunityInfo] = useState(pins[curPinIndex].pinOpportunity);
 
     useEffect(() => {
         fetchCurTextVal();
         pins[prevPinIndex].pinEfficacy = curEfficacyInfo;
+        pins[prevPinIndex].pinGoal = curGoalInfo;
+        pins[prevPinIndex].pinStrength = curStrengthInfo;
+        pins[prevPinIndex].pinOpportunity = curOpporunityInfo;
         setCurEfficacyInfo(pins[curPinIndex].pinEfficacy);
+        setCurGoalInfo(pins[curPinIndex].pinGoal);
+        setCurStrengthInfo(pins[curPinIndex].pinStrength);
+        setCurOpportunityInfo(pins[curPinIndex].pinOpportunity);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [curPinIndex])
 
@@ -96,15 +98,6 @@ const DissResponse = ({ curPinIndex, prevPinIndex }) => {
 
         setCurSkillInfo1(curPin.callerPinSkill);
         setCurSkillInfo2(curPin.calleePinSkill);
-
-        setCurGoalInfo1(curPin.callerPinGoal);
-        setCurGoalInfo2(curPin.calleePinGoal);
-
-        setCurStrengthInfo1(curPin.callerPinStrength);
-        setCurStrengthInfo2(curPin.calleePinStrength);
-
-        setCurOpportunityInfo1(curPin.callerPinOpportunity);
-        setCurOpportunityInfo2(curPin.calleePinOpportunity);
     }
 
     return (
@@ -130,8 +123,6 @@ const DissResponse = ({ curPinIndex, prevPinIndex }) => {
                     rows={3}
                     margin="normal"
                     value={curNoteInfo}
-                    inputRef={noteValueRef}
-                    onChange={() => console.log("invalid")}
                 />
                 <Box fontStyle="italic" marginTop="16px">
                     <Typography variant="h3">
@@ -214,99 +205,6 @@ const DissResponse = ({ curPinIndex, prevPinIndex }) => {
                         value={curSkillInfo2}
                     />
                 </form>
-                
-                <Box textAlign="left">
-                    <Typography>
-                        What was the goal during the pinned situation?
-                    </Typography>
-                </Box>
-                <form className={classes.root} noValidate autoCo
-                    mplete="off">
-                    <ColorLibTextField
-                        disabled
-                        id="outlined-secondary"
-                        label="caller's perspective"
-                        fullWidth
-                        variant="outlined"
-                        multiline
-                        rows={2}
-                        margin="normal"
-                        value={curGoalInfo1}
-                    />
-                    <ColorLibTextField
-                        disabled
-                        id="outlined-secondary"
-                        label="callee's perspective"
-                        fullWidth
-                        variant="outlined"
-                        multiline
-                        rows={2}
-                        margin="normal"
-                        value={curGoalInfo2}
-                    />
-                </form>
-
-                <Box textAlign="left">
-                    <Typography>
-                        What worked well to achieve the goal?
-                    </Typography>
-                </Box>
-                <form className={classes.root} noValidate autoCo
-                    mplete="off">
-                    <ColorLibTextField
-                        disabled
-                        id="outlined-secondary"
-                        label="caller's perspective"
-                        fullWidth
-                        variant="outlined"
-                        multiline
-                        rows={2}
-                        margin="normal"
-                        value={curStrengthInfo1}
-                    />
-                    <ColorLibTextField
-                        disabled
-                        id="outlined-secondary"
-                        label="callee's perspective"
-                        fullWidth
-                        variant="outlined"
-                        multiline
-                        rows={2}
-                        margin="normal"
-                        value={curStrengthInfo2}
-                    />
-                </form>
-
-                <Box textAlign="left">
-                    <Typography>
-                        What could be improved to achieve the goal?
-                    </Typography>
-                </Box>
-                <form className={classes.root} noValidate autoCo
-                    mplete="off">
-                    <ColorLibTextField
-                        disabled
-                        id="outlined-secondary"
-                        label="caller's perspective"
-                        fullWidth
-                        variant="outlined"
-                        multiline
-                        rows={2}
-                        margin="normal"
-                        value={curOpportunityInfo1}
-                    />
-                    <ColorLibTextField
-                        disabled
-                        id="outlined-secondary"
-                        label="callee's perspective"
-                        fullWidth
-                        variant="outlined"
-                        multiline
-                        rows={2}
-                        margin="normal"
-                        value={curOpportunityInfo2}
-                    />
-                </form>
 
                 <Box textAlign="left">
                     <Typography>
@@ -322,8 +220,62 @@ const DissResponse = ({ curPinIndex, prevPinIndex }) => {
                     rows={3}
                     margin="normal"
                     value={curEfficacyInfo}
-                    inputRef={noteValueRef}
-                    onChange={() => setCurEfficacyInfo(noteValueRef.current.value)}
+                    inputRef={efficacyValueRef}
+                    onChange={() => setCurEfficacyInfo(efficacyValueRef.current.value)}
+                />
+
+                <Box textAlign="left">
+                    <Typography>
+                        What was the goal during the pinned situation?
+                    </Typography>
+                </Box>
+                <ColorLibTextField
+                    id="outlined-secondary"
+                    label="Personal Notes..."
+                    fullWidth
+                    variant="outlined"
+                    multiline
+                    rows={3}
+                    margin="normal"
+                    value={curGoalInfo}
+                    inputRef={goalValueRef}
+                    onChange={() => setCurGoalInfo(goalValueRef.current.value)}
+                />
+
+                <Box textAlign="left">
+                    <Typography>
+                        What worked well to achieve the goal?
+                    </Typography>
+                </Box>
+                <ColorLibTextField
+                    id="outlined-secondary"
+                    label="Personal Notes..."
+                    fullWidth
+                    variant="outlined"
+                    multiline
+                    rows={3}
+                    margin="normal"
+                    value={curStrengthInfo}
+                    inputRef={strengthValueRef}
+                    onChange={() => setCurStrengthInfo(strengthValueRef.current.value)}
+                />
+
+                <Box textAlign="left">
+                    <Typography>
+                        What could be improved to achieve the goal?
+                    </Typography>
+                </Box>
+                <ColorLibTextField
+                    id="outlined-secondary"
+                    label="Personal Notes..."
+                    fullWidth
+                    variant="outlined"
+                    multiline
+                    rows={3}
+                    margin="normal"
+                    value={curOpporunityInfo}
+                    inputRef={opportunityValueRef}
+                    onChange={() => setCurOpportunityInfo(opportunityValueRef.current.value)}
                 />
             </ColorLibPaper>
         </Grid>

--- a/src/components/DissResponse.js
+++ b/src/components/DissResponse.js
@@ -3,6 +3,8 @@ import { makeStyles } from '@material-ui/core/styles';
 import { formatTime } from '../helper/index';
 import { Box, Grid, Paper, Typography } from '@material-ui/core';
 import { ToggleButton, ToggleButtonGroup } from '@material-ui/lab';
+
+import { ColorLibNextButton, ColorLibBackButton } from './layout/ColorLibComponents/ColorLibButton';
 import ColorLibPaper from './layout/ColorLibComponents/ColorLibPaper';
 import ColorLibTextField from './layout/ColorLibComponents/ColorLibTextField';
 import MISkillsSheet from './layout/MISkillsSheet';
@@ -12,7 +14,7 @@ import { usePins } from '../hooks/index';
 import { firebase } from "../hooks/firebase";
 
 //context
-import { useSessionValue, useUserModeValue, usePinsValue } from '../context';
+import { useSessionValue, useUserModeValue, usePinsValue, PinsProvider } from '../context';
 import { format } from 'url';
 
 const useStyles = makeStyles((theme) => ({
@@ -30,7 +32,7 @@ const useStyles = makeStyles((theme) => ({
     },
 }));
 
-const DissResponse = ({ curPinIndex, prevPinIndex }) => {
+const DissResponse = ({ curPinIndex, setCurPinIndex, prevPinIndex, setPrevPinIndex }) => {
     // user mode switcher
     const { userMode } = useUserModeValue();
 
@@ -98,6 +100,45 @@ const DissResponse = ({ curPinIndex, prevPinIndex }) => {
 
         setCurSkillInfo1(curPin.callerPinSkill);
         setCurSkillInfo2(curPin.calleePinSkill);
+    }
+
+    const handlePrevPin = () => {
+        setPrevPinIndex(curPinIndex);
+        setCurPinIndex(curPinIndex - 1);
+    }
+
+    const handleNextPin = () => {
+        setPrevPinIndex(curPinIndex);
+        setCurPinIndex(curPinIndex + 1);
+    }
+
+    const PinNavButtons = () => {
+        if (curPinIndex === -1)
+            return null;
+        const prev = 
+            <ColorLibBackButton 
+                variant="contained"
+                size="small"
+                onClick={handlePrevPin}
+            >
+                Prev Pin
+            </ColorLibBackButton>
+        const next = 
+            <ColorLibNextButton 
+                variant="contained"
+                size="small"
+                onClick={handleNextPin}
+            >
+                Next Pin
+            </ColorLibNextButton>
+
+        if (curPinIndex === 0) {
+            return next;
+        }
+        if (curPinIndex === pins.length -1) {
+            return prev;
+        }
+    return <div>{prev} {next}</div>;
     }
 
     return (
@@ -277,6 +318,10 @@ const DissResponse = ({ curPinIndex, prevPinIndex }) => {
                     inputRef={opportunityValueRef}
                     onChange={() => setCurOpportunityInfo(opportunityValueRef.current.value)}
                 />
+
+                <div style={{textAlign: 'center'}}>
+                    <PinNavButtons />
+                </div>
             </ColorLibPaper>
         </Grid>
     );

--- a/src/components/DissResponse.js
+++ b/src/components/DissResponse.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, Fragment } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import { formatTime } from '../helper/index';
 import { Box, Grid, Paper, Typography } from '@material-ui/core';
@@ -117,6 +117,7 @@ const DissResponse = ({ curPinIndex, setCurPinIndex, prevPinIndex, setPrevPinInd
             return null;
         const prev = 
             <ColorLibBackButton 
+                style={{margin: '0px 8px'}}
                 variant="contained"
                 size="small"
                 onClick={handlePrevPin}
@@ -125,6 +126,7 @@ const DissResponse = ({ curPinIndex, setCurPinIndex, prevPinIndex, setPrevPinInd
             </ColorLibBackButton>
         const next = 
             <ColorLibNextButton 
+                style={{margin: '0px 8px'}}
                 variant="contained"
                 size="small"
                 onClick={handleNextPin}
@@ -138,7 +140,7 @@ const DissResponse = ({ curPinIndex, setCurPinIndex, prevPinIndex, setPrevPinInd
         if (curPinIndex === pins.length -1) {
             return prev;
         }
-    return <div>{prev} {next}</div>;
+    return <Fragment> {prev} {next} </Fragment>;
     }
 
     return (
@@ -319,9 +321,9 @@ const DissResponse = ({ curPinIndex, setCurPinIndex, prevPinIndex, setPrevPinInd
                     onChange={() => setCurOpportunityInfo(opportunityValueRef.current.value)}
                 />
 
-                <div style={{textAlign: 'center'}}>
+                <Box textAlign='center'>
                     <PinNavButtons />
-                </div>
+                </Box>
             </ColorLibPaper>
         </Grid>
     );

--- a/src/components/Notetaking.js
+++ b/src/components/Notetaking.js
@@ -118,6 +118,7 @@ const Notetaking = ({ curPinIndex, setCurPinIndex, prevPinIndex, setPrevPinIndex
             return null;
         const prev = 
             <ColorLibBackButton 
+                style={{margin: '0px 8px'}}
                 variant="contained"
                 size="small"
                 onClick={handlePrevPin}
@@ -126,6 +127,7 @@ const Notetaking = ({ curPinIndex, setCurPinIndex, prevPinIndex, setPrevPinIndex
             </ColorLibBackButton>
         const next = 
             <ColorLibNextButton 
+                style={{margin: '0px 8px'}}
                 variant="contained"
                 size="small"
                 onClick={handleNextPin}
@@ -314,9 +316,9 @@ const Notetaking = ({ curPinIndex, setCurPinIndex, prevPinIndex, setPrevPinIndex
                     onChange={() => setCurSkillInfo(skillValueRef.current.value)}
                 />
 
-                <div style={{textAlign: 'center'}}>
+                <Box textAlign='center'>
                     <PinNavButtons />
-                </div>
+                </Box>
             </ColorLibPaper>
         </Grid>
     );

--- a/src/components/Notetaking.js
+++ b/src/components/Notetaking.js
@@ -62,9 +62,6 @@ const Notetaking = ({ curPinIndex, setCurPinIndex, prevPinIndex, setPrevPinIndex
     const noteValueRef = useRef('')
     const perspectiveValueRef = useRef('')
     const skillValueRef = useRef('')
-    const goalValueRef = useRef('')
-    const strengthValueRef = useRef('')
-    const opportunityValueRef = useRef('')
 
     // set up states for four different questions
     const [pinType, setPinType] = useState('');
@@ -72,9 +69,6 @@ const Notetaking = ({ curPinIndex, setCurPinIndex, prevPinIndex, setPrevPinIndex
     const [curNoteInfo, setCurNoteInfo] = useState('');
     const [curPerspectiveInfo, setCurPerspectiveInfo] = useState('');
     const [curSkillInfo, setCurSkillInfo] = useState('');
-    const [curGoalInfo, setCurGoalInfo] = useState('');
-    const [curStrengthInfo, setCurStrengthInfo] = useState('');
-    const [curOpportunityInfo, setCurOpportunityInfo] = useState('');
 
     const [pinBtnDisabled, setPinBtnDisabled] = useState(false);
     const [pinBtnColor, setPinBtnColor] = useState("");
@@ -114,9 +108,6 @@ const Notetaking = ({ curPinIndex, setCurPinIndex, prevPinIndex, setPrevPinIndex
                 myPin.callerPinPerspective = curPerspectiveInfo;
                 myPin.callerPinCategory = pinType;
                 myPin.callerPinSkill = curSkillInfo;
-                myPin.callerPinGoal = curGoalInfo;
-                myPin.callerPinStrength = curStrengthInfo;
-                myPin.callerPinOpportunity = curOpportunityInfo;
 
                 pins[index] = myPin;
             } else if(myPin) {
@@ -124,9 +115,6 @@ const Notetaking = ({ curPinIndex, setCurPinIndex, prevPinIndex, setPrevPinIndex
                 myPin.calleePinPerspective = curPerspectiveInfo;
                 myPin.calleePinCategory = pinType;
                 myPin.calleePinSkill = curSkillInfo;
-                myPin.calleePinGoal = curGoalInfo;
-                myPin.calleePinStrength = curStrengthInfo;
-                myPin.calleePinOpportunity = curOpportunityInfo;
 
                 pins[index] = myPin;
             }
@@ -142,17 +130,11 @@ const Notetaking = ({ curPinIndex, setCurPinIndex, prevPinIndex, setPrevPinIndex
         setCurNoteInfo(noteValueRef.current.value);
         setCurPerspectiveInfo(perspectiveValueRef.current.value);
         setCurSkillInfo(skillValueRef.current.value);
-        setCurGoalInfo(goalValueRef.current.value);
-        setCurStrengthInfo(strengthValueRef.current.value);
-        setCurOpportunityInfo(opportunityValueRef.current.value);
 
         //pin info saved
         console.log("Current note: " + curNoteInfo);
         console.log("Perspective info: " + curPerspectiveInfo);
         console.log("Skill Info: " + curSkillInfo);
-        console.log("Goal note: " + curGoalInfo);
-        console.log("Strength info: " + curStrengthInfo);
-        console.log("Opportunity Info: " + curOpportunityInfo);
 
         //save pin info
         savePin(prevPinIndex);
@@ -163,30 +145,16 @@ const Notetaking = ({ curPinIndex, setCurPinIndex, prevPinIndex, setPrevPinIndex
             setCurNoteInfo(pins[curPinIndex].callerPinNote);
             setCurPerspectiveInfo(pins[curPinIndex].callerPinPerspective);
             setCurSkillInfo(pins[curPinIndex].callerPinSkill);
-            setCurGoalInfo(pins[curPinIndex].callerPinGoal);
-            setCurStrengthInfo(pins[curPinIndex].callerPinStrength);
-            setCurOpportunityInfo(pins[curPinIndex].callerPinOpportunity);
         } else if(pins[curPinIndex]){
             setPinType(pins[curPinIndex].calleePinCategory);
             setCurNoteInfo(pins[curPinIndex].calleePinNote);
             setCurPerspectiveInfo(pins[curPinIndex].calleePinPerspective);
             setCurSkillInfo(pins[curPinIndex].calleePinSkill);
-            setCurGoalInfo(pins[curPinIndex].calleePinGoal);
-            setCurStrengthInfo(pins[curPinIndex].calleePinStrength);
-            setCurOpportunityInfo(pins[curPinIndex].calleePinOpportunity);
         }
         //reset all the refs
         noteValueRef.current.value = curNoteInfo;
         perspectiveValueRef.current.value = curPerspectiveInfo;
         skillValueRef.current.value = curSkillInfo;
-        goalValueRef.current.value = curGoalInfo;
-        strengthValueRef.current.value = curStrengthInfo;
-        opportunityValueRef.current.value = curOpportunityInfo;
-        console.log("Perspective info: " + curPerspectiveInfo);
-        console.log("Skill Info: " + curSkillInfo);
-        console.log("Goal note: " + curGoalInfo);
-        console.log("Strength info: " + curStrengthInfo);
-        console.log("Opportunity Info: " + curOpportunityInfo);
     }, [curPinIndex])
 
     // for pin information modifying
@@ -298,54 +266,6 @@ const Notetaking = ({ curPinIndex, setCurPinIndex, prevPinIndex, setPrevPinIndex
                     value={curSkillInfo}
                     inputRef={skillValueRef}
                     onChange={() => setCurSkillInfo(skillValueRef.current.value)}
-                />
-                <Box textAlign="left" >
-                    <Typography>
-                        What was the goal during the pinned situation?
-                    </Typography>
-                </Box>
-                <ColorLibTextField
-                    id="outlined-secondary"
-                    fullWidth
-                    variant="outlined"
-                    multiline
-                    rows={2}
-                    margin="normal"
-                    value={curGoalInfo}
-                    inputRef={goalValueRef}
-                    onChange={() => setCurGoalInfo(goalValueRef.current.value)}
-                />
-                <Box textAlign="left" >
-                    <Typography>
-                        What worked well to achieve the goal?
-                    </Typography>
-                </Box>
-                <ColorLibTextField
-                    id="outlined-secondary"
-                    fullWidth
-                    variant="outlined"
-                    multiline
-                    rows={2}
-                    margin="normal"
-                    value={curStrengthInfo}
-                    inputRef={strengthValueRef}
-                    onChange={() => setCurStrengthInfo(strengthValueRef.current.value)}
-                />
-                <Box textAlign="left" >
-                    <Typography>
-                        What could be improved to achieve the goal?
-                    </Typography>
-                </Box>
-                <ColorLibTextField
-                    id="outlined-secondary"
-                    fullWidth
-                    variant="outlined"
-                    multiline
-                    rows={2}
-                    margin="normal"
-                    value={curOpportunityInfo}
-                    inputRef={opportunityValueRef}
-                    onChange={() => setCurOpportunityInfo(opportunityValueRef.current.value)}
                 />
             </ColorLibPaper>
         </Grid>

--- a/src/components/Notetaking.js
+++ b/src/components/Notetaking.js
@@ -4,6 +4,8 @@ import { formatTime } from '../helper/index';
 import { makeStyles } from '@material-ui/core/styles';
 import { Box, Grid, Typography } from '@material-ui/core';
 import { ToggleButton, ToggleButtonGroup } from '@material-ui/lab';
+
+import { ColorLibNextButton, ColorLibBackButton } from './layout/ColorLibComponents/ColorLibButton';
 import ColorLibPaper from './layout/ColorLibComponents/ColorLibPaper';
 import ColorLibTextField from './layout/ColorLibComponents/ColorLibTextField';
 import MISkillsSheet from './layout/MISkillsSheet';
@@ -75,29 +77,71 @@ const Notetaking = ({ curPinIndex, setCurPinIndex, prevPinIndex, setPrevPinIndex
     const [audioProgress, setAudioProgress] = useState(0);
     const [loadURL, setLoadURL] = useState(false)
 
-    // back to last pin
-    const handleLastPin = (index) => {
-        console.log(audio);
-        console.log(audioLen);
-        console.log(audioProgress);
-        if (curPinIndex > 0) {
-            setCurPinIndex(index);
-            player.current.seekTo(parseFloat(pins.map(pin => pin.pinTime)[index]));
-        }
-    };
+    // // back to last pin
+    // const handleLastPin = (index) => {
+    //     console.log(audio);
+    //     console.log(audioLen);
+    //     console.log(audioProgress);
+    //     if (curPinIndex > 0) {
+    //         setCurPinIndex(index);
+    //         player.current.seekTo(parseFloat(pins.map(pin => pin.pinTime)[index]));
+    //     }
+    // };
 
-    // go to next pin
-    const handleNextPin = (index, remove = false) => {
-        if (curPinIndex < pins.map(pin => pin.pinTime).length - 1) {
-            if (!remove) {
-                player.current.seekTo(parseFloat(pins.map(pin => pin.pinTime)[index]));
-                setCurPinIndex(index);
-            } else {
-                player.current.seekTo(parseFloat(pins.map(pin => pin.pinTime)[index]));
-                setCurPinIndex(index - 1);
-            }
+    // // go to next pin
+    // const handleNextPin = (index, remove = false) => {
+    //     if (curPinIndex < pins.map(pin => pin.pinTime).length - 1) {
+    //         if (!remove) {
+    //             player.current.seekTo(parseFloat(pins.map(pin => pin.pinTime)[index]));
+    //             setCurPinIndex(index);
+    //         } else {
+    //             player.current.seekTo(parseFloat(pins.map(pin => pin.pinTime)[index]));
+    //             setCurPinIndex(index - 1);
+    //         }
+    //     }
+    // };
+
+
+
+    const handlePrevPin = () => {
+        setPrevPinIndex(curPinIndex);
+        setCurPinIndex(curPinIndex - 1);
+    }
+
+    const handleNextPin = () => {
+        setPrevPinIndex(curPinIndex);
+        setCurPinIndex(curPinIndex + 1);
+    }
+
+    const PinNavButtons = () => {
+        if (curPinIndex === -1)
+            return null;
+        const prev = 
+            <ColorLibBackButton 
+                variant="contained"
+                size="small"
+                onClick={handlePrevPin}
+            >
+                Prev Pin
+            </ColorLibBackButton>
+        const next = 
+            <ColorLibNextButton 
+                variant="contained"
+                size="small"
+                onClick={handleNextPin}
+            >
+                Next Pin
+            </ColorLibNextButton>
+
+        if (curPinIndex === 0) {
+            return next;
         }
-    };
+        if (curPinIndex === pins.length -1) {
+            return prev;
+        }
+    return <div>{prev} {next}</div>;
+    }
+
 
     const savePin = async (index) => {
         console.log("pins:" + pins + "\nindex: " + index);
@@ -188,6 +232,8 @@ const Notetaking = ({ curPinIndex, setCurPinIndex, prevPinIndex, setPrevPinIndex
         // handlePinInfo(`${userMode}PinInfos.pinCategory`, newPinType);
     };
 
+    
+
     return (
         <Grid item xs={12} sm={8}>
             <ColorLibPaper elevation={1}>
@@ -267,6 +313,10 @@ const Notetaking = ({ curPinIndex, setCurPinIndex, prevPinIndex, setPrevPinIndex
                     inputRef={skillValueRef}
                     onChange={() => setCurSkillInfo(skillValueRef.current.value)}
                 />
+
+                <div style={{textAlign: 'center'}}>
+                    <PinNavButtons />
+                </div>
             </ColorLibPaper>
         </Grid>
     );

--- a/src/components/VideoChatComponent.js
+++ b/src/components/VideoChatComponent.js
@@ -62,7 +62,8 @@ const useStyles = makeStyles((theme) => ({
       '& video': {
         borderRadius: '5px',
         width: '100%',
-        height: 'max-content',
+        height: '100%',
+        backgroundColor: 'black',
       },
       '& .MuiFab-root': {
         left: 'calc(50% - 50px)',
@@ -419,6 +420,13 @@ function VideoChatComponent(props) {
         console.log("start chat now");
         setIsInterviewStarted(true);
         setVideoCallTimer(Date.now());
+        // Disable audio / video buttons as set before
+        if (!isAudioEnabled) {
+          onToggleAudio(false);
+        }
+        if (!isVideoEnabled) {
+          onToggleVideo(false);
+        }
         if (props.isArchiveHost) {
           //props.startRec();
           console.log("start recording");
@@ -589,7 +597,7 @@ function VideoChatComponent(props) {
       >
         <DialogContent>
           <DialogContentText id="alert-dialog-description">
-            <div style={{marginRight: '20px'}}>
+            <div style={{marginRight: '20px', width: 'calc(45% - 20px)'}}>
               <img 
                 src={pinningClick} 
                 alt={"Icon of clicking the pin"}
@@ -622,11 +630,18 @@ function VideoChatComponent(props) {
                 </ColorLibNextButton>
               </div>
             </div>
-            <div style={{Width: '100%'}}>
-              <Webcam 
+            <div style={{width: '55%'}}>
+              {isVideoEnabled 
+              ? <Webcam 
                 mirrored
                 audio={isAudioEnabled} 
-              />
+              /> 
+              : <div style={{
+                height: '100%',
+                width: '100%',
+                backgroundColor: 'black',
+                borderRadius: '5px'
+              }}/>}
               <div style={{marginTop: '-65px'}}>
                 <PreviewMicButton />
                 <PreviewVideoButton />

--- a/src/components/VideoChatComponent.js
+++ b/src/components/VideoChatComponent.js
@@ -206,17 +206,14 @@ function VideoChatComponent(props) {
         callerPinPerspective: '',
         callerPinCategory: '',
         callerPinSkill: '',
-        callerPinGoal: '',
-        callerPinStrength: '',
-        callerPinOpportunity: '',
         calleePinNote: '',
         calleePinPerspective: '',
         calleePinCategory: '',
         calleePinSkill: '',
-        calleePinGoal: '',
-        calleePinStrength: '',
-        calleePinOpportunity: '',
-        pinEfficacy: ''
+        pinEfficacy: '',
+        pinGoal: '',
+        pinStrength: '',
+        pinOpportunity: '',
       }; 
 
       //Use this code if the pins context doesn't work correctly to save pin information from both users

--- a/src/components/VideoDiscussionSecond.js
+++ b/src/components/VideoDiscussionSecond.js
@@ -179,8 +179,8 @@ function VideoChatComponentSecond(props) {
         pinTime: curTime,
         // pinInfos: {"pinNote": "", "pinPerspective": "", "pinCategory": "", "pinSkill": ""},
         sessionID: MiTrainingSessionID,
-        callerPinInfos: {"pinNote": "", "pinPerspective": "", "pinCategory": "", "pinSkill": "", "pinGoal":"", "pinStrength":"", "pinOpportunity": ""},
-        calleePinInfos: {"pinNote": "", "pinPerspective": "", "pinCategory": "", "pinSkill": "", "pinGoal":"", "pinStrength":"", "pinOpportunity": ""},
+        callerPinInfos: {"pinNote": "", "pinPerspective": "", "pinCategory": "", "pinSkill": ""},
+        calleePinInfos: {"pinNote": "", "pinPerspective": "", "pinCategory": "", "pinSkill": ""},
     })        
     .then( () => {
         setPins([...pins, ]);

--- a/src/components/layout/Collaboration.jsx
+++ b/src/components/layout/Collaboration.jsx
@@ -30,6 +30,20 @@ const useStyles = makeStyles((theme) => ({
     "& .MuiGrid-item": {
       display: 'inline-grid',
     },
+    "& .MuiGrid-grid-sm-4": {
+      position: 'relative',
+      margin: '8px',
+      maxWidth: 'calc(33.333333% - 8px)',
+      "& .MuiPaper-root": {
+        position: 'absolute',
+        top: 0,
+        bottom: 0,
+        overflowY: 'scroll',
+      }
+    },
+    "& .MuiGrid-grid-sm-8": {
+      maxWidth: 'calc(66.666667% - 8px)',
+    }
   },
 }));
 

--- a/src/components/layout/Collaboration.jsx
+++ b/src/components/layout/Collaboration.jsx
@@ -63,7 +63,9 @@ const Collaboration = ({curPinIndex, setCurPinIndex, prevPinIndex, setPrevPinInd
           <Transcription />
           <DissResponse 
             curPinIndex = {curPinIndex}
+            setCurPinIndex = {setCurPinIndex}
             prevPinIndex = {prevPinIndex}
+            setPrevPinIndex = {setPrevPinIndex}
             />
         </Grid>
       </Container>

--- a/src/components/layout/DisscussionPrep.jsx
+++ b/src/components/layout/DisscussionPrep.jsx
@@ -59,17 +59,14 @@ const DisscussionPrep = () => {
       callerPinPerspective: myPin.callerPinPerspective,
       callerPinCategory: myPin.callerPinCategory,
       callerPinSkill: myPin.callerPinSkill,
-      callerPinGoal: myPin.callerPinGoal,
-      callerPinStrength: myPin.callerPinStrength,
-      callerPinOpportunity: myPin.callerPinOpportunity,
       calleePinNote: myPin.calleePinNote,
       calleePinPerspective: myPin.calleePinPerspective,
       calleePinCategory: myPin.calleePinCategory,
       calleePinSkill: myPin.calleePinSkill,
-      calleePinGoal: myPin.callerPinGoal,
-      calleePinStrength: myPin.calleePinStrength,
-      calleePinOpportunity: myPin.calleePinOpportunity,
-      pinEfficacy: ''
+      pinEfficacy: '',
+      pinGoal: '',
+      pinStrength: '',
+      pinOpportunity: '',
     })
     .then((docRef) => { pins[index].pinID = docRef.id; console.log("current pin successfully updated") })
     .catch((e) => { console.log("pin update unsuccessful: " + e) });

--- a/src/components/layout/DisscussionPrep.jsx
+++ b/src/components/layout/DisscussionPrep.jsx
@@ -32,6 +32,20 @@ const useStyles = makeStyles((theme) => ({
     "& .MuiGrid-item": {
       display: 'inline-grid',
     },
+    "& .MuiGrid-grid-sm-4": {
+      position: 'relative',
+      margin: '8px',
+      maxWidth: 'calc(33.333333% - 8px)',
+      "& .MuiPaper-root": {
+        position: 'absolute',
+        top: 0,
+        bottom: 0,
+        overflowY: 'scroll',
+      }
+    },
+    "& .MuiGrid-grid-sm-8": {
+      maxWidth: 'calc(66.666667% - 8px)',
+    }
   },
 }));
 

--- a/src/components/layout/SelfReflection.jsx
+++ b/src/components/layout/SelfReflection.jsx
@@ -7,10 +7,10 @@ import ColorLibTextField from './ColorLibComponents/ColorLibTextField';
 import ColorLibPaper from './ColorLibComponents/ColorLibPaper';
 
 import firebase from 'firebase';
-import { useSessionValue, useUserModeValue} from '../../context';
+import { useSessionValue, useUserModeValue } from '../../context';
 
 const getPageTitle = (page) => {
-    switch(page) {
+    switch (page) {
         case 0: return "Based on today’s session";
         case 1: return "Make a plan";
         case 2: return "Prepare for change";
@@ -22,16 +22,16 @@ const getPageTitle = (page) => {
 
 const getPageButtons = (page, setPage, makeReflectionDoc) => {
     const handleNext = () => {
-        setPage(page+1);
+        setPage(page + 1);
     }
     const handleBack = () => {
-        setPage(page-1);
+        setPage(page - 1);
     }
-    switch(page) {
+    switch (page) {
         case 0: return (
-            <ColorLibNextButton 
-                variant="contained" 
-                size="medium" 
+            <ColorLibNextButton
+                variant="contained"
+                size="medium"
                 onClick={handleNext}
             >
                 Next
@@ -39,16 +39,16 @@ const getPageButtons = (page, setPage, makeReflectionDoc) => {
         );
         case 1: return (
             <div>
-                <ColorLibBackButton 
-                    variant="outlined" 
+                <ColorLibBackButton
+                    variant="outlined"
                     size="medium"
                     onClick={handleBack}
                 >
                     Back
                 </ColorLibBackButton>
-                <ColorLibNextButton 
-                    variant="contained" 
-                    size="medium" 
+                <ColorLibNextButton
+                    variant="contained"
+                    size="medium"
                     onClick={handleNext}
                 >
                     Next
@@ -57,17 +57,17 @@ const getPageButtons = (page, setPage, makeReflectionDoc) => {
         );
         case 2: return (
             <div>
-                <ColorLibBackButton 
-                    variant="outlined" 
+                <ColorLibBackButton
+                    variant="outlined"
                     size="medium"
                     onClick={handleBack}
                 >
                     Back
                 </ColorLibBackButton>
-                <ColorLibNextButton 
+                <ColorLibNextButton
                     variant="contained"
                     size="medium"
-                    onClick={()=>makeReflectionDoc()}
+                    onClick={() => makeReflectionDoc()}
                 >
                     Finish Self-Reflection
                 </ColorLibNextButton>
@@ -78,108 +78,108 @@ const getPageButtons = (page, setPage, makeReflectionDoc) => {
 }
 
 const SelfReflection = () => {
-    const {sessionID} = useSessionValue();
-    const {userID} = useUserModeValue();
+    const { sessionID } = useSessionValue();
+    const { userID } = useUserModeValue();
 
     const [page, setPage] = useState(0);
 
     // const childRef = React.createRef();
 
     const [strength, setStrength] = useState('');
-        const [opp, setOpp] = useState('');
-        const [nextSteps, setNextSteps] = useState('');
-        const [obstacles, setObstacles] = useState('');
-        const [practice, setPractice] = useState('');
-        const [addReflect, setAddReflect] = useState('');
-    
-        const strengthRef = useRef('');
-        const oppRef = useRef('');
-        const nextStepsRef = useRef('');
-        const obstaclesRef = useRef('');
-        const practiceRef = useRef('');
-        const addReflectRef = useRef('');
+    const [opp, setOpp] = useState('');
+    const [nextSteps, setNextSteps] = useState('');
+    const [obstacles, setObstacles] = useState('');
+    const [practice, setPractice] = useState('');
+    const [addReflect, setAddReflect] = useState('');
+
+    const strengthRef = useRef('');
+    const oppRef = useRef('');
+    const nextStepsRef = useRef('');
+    const obstaclesRef = useRef('');
+    const practiceRef = useRef('');
+    const addReflectRef = useRef('');
 
     const GetPageContent = (page) => {
         console.log("In GetPageContent: ");
         console.log(page.page);
-        switch(page.page) {
+        switch (page.page) {
             case 0: return (
                 <div>
-                    <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" > 
-                        What do I feel like are my strengths?                              
+                    <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" >
+                        What do I feel like are my strengths?
                     </Box>
                     <Box>
                         <ColorLibTextField
-                                id="outlined-secondary"
-                                label="Type a strength..."
-                                fullWidth
-                                variant="outlined"
-                                multiline
-                                rowsMax={2}
-                                margin="normal"
-                                value={strength}
-                                inputRef={strengthRef}
-                                onChange={() => setStrength(strengthRef.current.value)}
+                            id="outlined-secondary"
+                            label="Type a strength..."
+                            fullWidth
+                            variant="outlined"
+                            multiline
+                            rowsMax={2}
+                            margin="normal"
+                            value={strength}
+                            inputRef={strengthRef}
+                            onChange={() => setStrength(strengthRef.current.value)}
                         />
                     </Box>
-                    <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" > 
+                    <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" >
                         What are some opportunities for growth?
                     </Box>
                     <Box>
                         <ColorLibTextField
-                                id="outlined-secondary"
-                                label="Type an opportunity..."
-                                fullWidth
-                                variant="outlined"
-                                multiline
-                                rowsMax={2}
-                                margin="normal"
-                                value={opp}
-                                inputRef={oppRef}
-                                onChange={()=>setOpp(oppRef.current.value)}
+                            id="outlined-secondary"
+                            label="Type an opportunity..."
+                            fullWidth
+                            variant="outlined"
+                            multiline
+                            rowsMax={2}
+                            margin="normal"
+                            value={opp}
+                            inputRef={oppRef}
+                            onChange={() => setOpp(oppRef.current.value)}
                         />
                     </Box>
                 </div>
             );
             case 1: return (
                 <div>
-                    <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" > 
+                    <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" >
                         What steps will I take to improve?
                     </Box>
                     <Box>
                         <ColorLibTextField
-                                id="outlined-secondary"
-                                fullWidth
-                                variant="outlined"
-                                multiline
-                                rowsMax={2}
-                                margin="normal"
-                                value={nextSteps}
-                                inputRef={nextStepsRef}
-                                onChange={() => setNextSteps(nextStepsRef.current.value)}
+                            id="outlined-secondary"
+                            fullWidth
+                            variant="outlined"
+                            multiline
+                            rowsMax={2}
+                            margin="normal"
+                            value={nextSteps}
+                            inputRef={nextStepsRef}
+                            onChange={() => setNextSteps(nextStepsRef.current.value)}
                         />
                     </Box>
-                    <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" > 
+                    <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" >
                         What obstacles might get in the way, and how will I overcome them?
                     </Box>
                     <Box>
                         <ColorLibTextField
-                                id="outlined-secondary"
-                                fullWidth
-                                variant="outlined"
-                                multiline
-                                rowsMax={2}
-                                margin="normal"
-                                value={obstacles}
-                                inputRef={obstaclesRef}
-                                onChange={() => setObstacles(obstaclesRef.current.value)}
+                            id="outlined-secondary"
+                            fullWidth
+                            variant="outlined"
+                            multiline
+                            rowsMax={2}
+                            margin="normal"
+                            value={obstacles}
+                            inputRef={obstaclesRef}
+                            onChange={() => setObstacles(obstaclesRef.current.value)}
                         />
                     </Box>
                 </div>
             );
             case 2: return (
                 <div>
-                    <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" > 
+                    <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" >
                         What would I like to add to my clinical practice?
                     </Box>
                     <Box>
@@ -195,20 +195,20 @@ const SelfReflection = () => {
                             onChange={() => setPractice(practiceRef.current.value)}
                         />
                     </Box>
-                    <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" > 
+                    <Box textAlign="left" fontSize={18} fontWeight="fontWeightMedium" >
                         What else would I like to keep reflecting on during the next week?
                     </Box>
                     <Box>
                         <ColorLibTextField
-                                id="outlined-secondary"
-                                fullWidth
-                                variant="outlined"
-                                multiline
-                                rowsMax={2}
-                                margin="normal"
-                                value={addReflect}
-                                inputRef={addReflectRef}
-                                onChange={() => setAddReflect(addReflectRef.current.value)}
+                            id="outlined-secondary"
+                            fullWidth
+                            variant="outlined"
+                            multiline
+                            rowsMax={2}
+                            margin="normal"
+                            value={addReflect}
+                            inputRef={addReflectRef}
+                            onChange={() => setAddReflect(addReflectRef.current.value)}
                         />
                     </Box>
                 </div>
@@ -231,23 +231,23 @@ const SelfReflection = () => {
     }
 
     return (
-        <Container maxWidth = 'md'>
+        <Container maxWidth='md'>
             <Typography variant='h2'>
                 Reflect on how the session went and how you felt.
             </Typography>
-            <ColorLibPaper 
+            <ColorLibPaper
                 elevation={0}
-                style={{margin:'24px 0px'}}
+                style={{ margin: '24px 0px' }}
             >
                 <Typography variant='h4'>
                     {getPageTitle(page)}
-                </Typography>  
-                <GetPageContent page={page}/>
-                <div 
+                </Typography>
+                <GetPageContent page={page} />
+                <div
                     style={{
-                        display: 'flex', 
-                        alignItems: 'center', 
-                        justifyContent: 'center', 
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
                         margin: '20px 0 0 0'
                     }}
                 >
@@ -257,5 +257,5 @@ const SelfReflection = () => {
         </Container>
     );
 }
- 
+
 export default SelfReflection;

--- a/src/components/layout/SelfReflection.jsx
+++ b/src/components/layout/SelfReflection.jsx
@@ -40,6 +40,7 @@ const getPageButtons = (page, setPage, makeReflectionDoc) => {
         case 1: return (
             <div>
                 <ColorLibBackButton
+                    style={{margin: '0px 8px'}}
                     variant="outlined"
                     size="medium"
                     onClick={handleBack}
@@ -47,6 +48,7 @@ const getPageButtons = (page, setPage, makeReflectionDoc) => {
                     Back
                 </ColorLibBackButton>
                 <ColorLibNextButton
+                    style={{margin: '0px 8px'}}
                     variant="contained"
                     size="medium"
                     onClick={handleNext}
@@ -58,6 +60,7 @@ const getPageButtons = (page, setPage, makeReflectionDoc) => {
         case 2: return (
             <div>
                 <ColorLibBackButton
+                    style={{margin: '0px 8px'}}
                     variant="outlined"
                     size="medium"
                     onClick={handleBack}
@@ -65,6 +68,7 @@ const getPageButtons = (page, setPage, makeReflectionDoc) => {
                     Back
                 </ColorLibBackButton>
                 <ColorLibNextButton
+                    style={{margin: '0px 8px'}}
                     variant="contained"
                     size="medium"
                     onClick={() => makeReflectionDoc()}


### PR DESCRIPTION
### Description of Updates
- Previously, though the users can preview and disable the audio/video buttons, they do not correspond correctly with the actual audio and video. The new update fixes the problem by pre-setting the audio/video states immediately after loading.
- Aside from navigation through the audio player, we should also have a set of prev/next navigation buttons on the Discussion Prep and Discussion page to navigate through the pins.
- The Transcription should be scrollable when it is really long.
- Minor Updates:
    - The new questions were added to the wrong pages in the previous PR. They are moved to the Discussion page now.
    - Adds margin between Prev/Next buttons on the Discussion Prep page, Discussion page, and Self-Reflection page.

Demo of the video preview and disable/enable functionality:

https://user-images.githubusercontent.com/55717622/138202722-ea7f960e-5b89-42dc-be9d-e94ced74158d.mov

Demo of the rest of the tour:

https://user-images.githubusercontent.com/55717622/138202747-7d07de67-654d-4749-a9dc-439a40ea9b3c.mov



### Next steps
- All issues fixed! Dobbie is free >:D (until Friday, I guess.)