### PR TITLE
Component refining

### DIFF
--- a/src/components/AudioReview.js
+++ b/src/components/AudioReview.js
@@ -90,7 +90,6 @@ const AudioReview = ({curPinIndex, setCurPinIndex, prevPinIndex, setPrevPinIndex
             calleePinPerspective: '',
             calleePinCategory: '',
             calleePinSkill: '',
-            pinEfficacy: '',
             pinGoal: '',
             pinStrength: '',
             pinOpportunity: '',

--- a/src/components/AudioReview.js
+++ b/src/components/AudioReview.js
@@ -33,11 +33,15 @@ const AudioReview = ({curPinIndex, setCurPinIndex, prevPinIndex, setPrevPinIndex
 
     const [pinBtnDisabled, setPinBtnDisabled] = useState(false); 
     const [pinBtnColor, setPinBtnColor] = useState("");
-    const [audioProgress, setAudioProgress] = useState(0);
+    const [audioProgress, setAudioProgress] = useState(Math.max(0, pins[0].pinTime - 10));
     const [audioPlaying, setAudioPlaying] = useState(false);
     
     const [loadURL, setLoadURL] = useState(false)
     
+    useEffect(() => {
+        const time = pins[curPinIndex].pinTime;
+        setAudioProgress(Math.max(0, time - 10));
+    }, [curPinIndex]);
 
     let playTimeArr = pins.map(pin => pin.pinTime);
 

--- a/src/components/DissResponse.js
+++ b/src/components/DissResponse.js
@@ -39,7 +39,6 @@ const DissResponse = ({ curPinIndex, setCurPinIndex, prevPinIndex, setPrevPinInd
     const classes = useStyles();
 
     //creating a refernce for TextField Components
-    const efficacyValueRef = useRef('')
     const goalValueRef = useRef('')
     const strengthValueRef = useRef('')
     const opportunityValueRef = useRef('')
@@ -64,18 +63,15 @@ const DissResponse = ({ curPinIndex, setCurPinIndex, prevPinIndex, setPrevPinInd
     const [curSkillInfo1, setCurSkillInfo1] = useState('');
     const [curSkillInfo2, setCurSkillInfo2] = useState('');
 
-    const [curEfficacyInfo, setCurEfficacyInfo] = useState(pins[curPinIndex].pinEfficacy);
     const [curGoalInfo, setCurGoalInfo] = useState(pins[curPinIndex].pinGoal);
     const [curStrengthInfo, setCurStrengthInfo] = useState(pins[curPinIndex].pinStrength);
     const [curOpporunityInfo, setCurOpportunityInfo] = useState(pins[curPinIndex].pinOpportunity);
 
     useEffect(() => {
         fetchCurTextVal();
-        pins[prevPinIndex].pinEfficacy = curEfficacyInfo;
         pins[prevPinIndex].pinGoal = curGoalInfo;
         pins[prevPinIndex].pinStrength = curStrengthInfo;
         pins[prevPinIndex].pinOpportunity = curOpporunityInfo;
-        setCurEfficacyInfo(pins[curPinIndex].pinEfficacy);
         setCurGoalInfo(pins[curPinIndex].pinGoal);
         setCurStrengthInfo(pins[curPinIndex].pinStrength);
         setCurOpportunityInfo(pins[curPinIndex].pinOpportunity);
@@ -248,24 +244,6 @@ const DissResponse = ({ curPinIndex, setCurPinIndex, prevPinIndex, setPrevPinInd
                         value={curSkillInfo2}
                     />
                 </form>
-
-                <Box textAlign="left">
-                    <Typography>
-                        Why was the pinned situation effective or ineffective?
-                    </Typography>
-                </Box>
-                <ColorLibTextField
-                    id="outlined-secondary"
-                    label="Personal Notes..."
-                    fullWidth
-                    variant="outlined"
-                    multiline
-                    rows={3}
-                    margin="normal"
-                    value={curEfficacyInfo}
-                    inputRef={efficacyValueRef}
-                    onChange={() => setCurEfficacyInfo(efficacyValueRef.current.value)}
-                />
 
                 <Box textAlign="left">
                     <Typography>

--- a/src/components/VideoChatComponent.js
+++ b/src/components/VideoChatComponent.js
@@ -102,7 +102,7 @@ function VideoChatComponent(props) {
       case 0: 
         return "Don’t forget to pin at least twice";
       case 1:
-        const pinTime = Math.floor((Date.now() - videoCallTimer) / 1000);
+        const pinTime = pins[pins.length - 1].pinTime;
         return `Successfully pinned at ${formatTime(pinTime)}`;
       default: 
         return "Invalid Pin Content."
@@ -124,7 +124,7 @@ function VideoChatComponent(props) {
     setPopperOpen(true);
     setTimeout(() => {
       setPopperOpen(false);
-    }, 1000);
+    }, 3000);
   }
 
   const [open, setOpen] = useState(true);
@@ -478,9 +478,19 @@ function VideoChatComponent(props) {
         startSpeechToText();
         setPopperOpen(true);
         setTimeout(() => {
+          if (popperContentIndex === 0) {
+            setPopperOpen(false);
+          }
+        }, 5000);
+        setTimeout(() => {
           setPopperOpen(true);
           setPopperContentIndex(0);
-        }, 300000);
+        }, 30000);
+        setTimeout(() => {
+          if (popperContentIndex === 0) {
+            setPopperOpen(false);
+          }
+        }, 35000);
       })
       .catch((error) => { console.log(error) });
   }

--- a/src/components/VideoChatComponent.js
+++ b/src/components/VideoChatComponent.js
@@ -484,12 +484,12 @@ function VideoChatComponent(props) {
         setTimeout(() => {
           setPopperOpen(true);
           setPopperContentIndex(0);
-        }, 30000);
+        }, 300000);
         setTimeout(() => {
           if (popperContentIndex === 0) {
             setPopperOpen(false);
           }
-        }, 35000);
+        }, 305000);
       })
       .catch((error) => { console.log(error) });
   }

--- a/src/components/VideoChatComponent.js
+++ b/src/components/VideoChatComponent.js
@@ -232,7 +232,6 @@ function VideoChatComponent(props) {
         calleePinPerspective: '',
         calleePinCategory: '',
         calleePinSkill: '',
-        pinEfficacy: '',
         pinGoal: '',
         pinStrength: '',
         pinOpportunity: '',

--- a/src/components/layout/Discussion.jsx
+++ b/src/components/layout/Discussion.jsx
@@ -34,7 +34,6 @@ const Discussion = () => {
     console.log("before");
     if (finishedUpdates) {
       console.log("after");
-      saveEfficacyInfo(pins, sessionID);
       setPage(page + 1);
     }
   }, [finishedUpdates]);
@@ -50,14 +49,6 @@ const Discussion = () => {
       default:
         return <div>Unknown</div>;
     }
-  }
-
-  const saveEfficacyInfo = async (pins, sessionID) => {
-    pins.map(async (p) => {
-      await firebase.firestore().collection("sessions").doc(sessionID).collection("pins").doc(p.pinID).update({
-        pinEfficacy: p.pinEfficacy
-      })
-    })
   }
 
   const handleButton = (finished) => {

--- a/src/components/layout/DisscussionPrep.jsx
+++ b/src/components/layout/DisscussionPrep.jsx
@@ -91,7 +91,6 @@ const DisscussionPrep = () => {
       calleePinPerspective: myPin.calleePinPerspective,
       calleePinCategory: myPin.calleePinCategory,
       calleePinSkill: myPin.calleePinSkill,
-      pinEfficacy: '',
       pinGoal: '',
       pinStrength: '',
       pinOpportunity: '',


### PR DESCRIPTION
### Updates
- Make the “don’t forget to pin” go away after 5 seconds.
- Use static pin time instead of dynamic time in the “pinned at x seconds” so that the users don't see the time change. Make the success message stay for 3 seconds. 
- The first question in the discussion section (why was the pin situation effective) should be removed.
- Connect the next/prev pin to audio bar.  Set the audio to 10 seconds before the first pin

https://user-images.githubusercontent.com/55717622/140184969-768453b6-4444-4b3d-bcb8-1d46951cdbb9.mov

### Problems
- After the next/prev buttons and audio bar got connected, there is some mingling between the 2 actions since they are controlled by the same variable (curPinIndex). When you drag on the slider, on the first pin index change the thumb may jump back for 10 seconds.