### PR TITLE
Pin Time should start after archiving has started

### DIFF
--- a/src/components/VideoChatComponent.js
+++ b/src/components/VideoChatComponent.js
@@ -109,7 +109,6 @@ function VideoChatComponent(props) {
         const thisPin = pins[pins.length - 1];
         const pinTime = thisPin.pinTime;
         const pinCreatorMode = thisPin.creatorMode;
-        console.log(pinCreatorMode, user.userMode);
         return `Successfully pinned at ${formatTime(pinTime)}`;
       default:
         return "Invalid Pin Content."
@@ -198,9 +197,10 @@ function VideoChatComponent(props) {
 
   useEffect(() => {
     const timer = setTimeout(() => {
-      if (!open && countDown > 0) {
+      if (!open && countDown > 0 && videoCallTimer != 0) {
         const timePassed = (Date.now() - videoCallTimer) / 1000;
         if (timePassed >= recommendedTime) {
+          console.log("Time passed: " + timePassed);
           setCountDown(0);
           setTimeRemind(true);
         } else {
@@ -510,7 +510,7 @@ function VideoChatComponent(props) {
         setLoadingStatus(false);
         console.log("start chat now");
         setIsInterviewStarted(true);
-        setVideoCallTimer(Date.now());
+        // setVideoCallTimer(Date.now());
         // Disable audio / video buttons as set before
         if (!isAudioEnabled) {
           onToggleAudio(false);
@@ -524,21 +524,6 @@ function VideoChatComponent(props) {
         }
         //pass in videoCallTimer so we can create time stamps
         startSpeechToText();
-        setPopperOpen(true);
-        setTimeout(() => {
-          if (popperContentIndex === 0) {
-            setPopperOpen(false);
-          }
-        }, 5000);
-        setTimeout(() => {
-          setPopperOpen(true);
-          setPopperContentIndex(0);
-        }, 300000);
-        setTimeout(() => {
-          if (popperContentIndex === 0) {
-            setPopperOpen(false);
-          }
-        }, 305000);
       })
       .catch((error) => { console.log(error) });
   }
@@ -586,6 +571,23 @@ function VideoChatComponent(props) {
       //and turn it into json so you can access data from it
       .then(response => response.json())
       .then((archiveData) => {
+        setVideoCallTimer(Date.now());
+        setPopperOpen(true);
+        setTimeout(() => {
+          if (popperContentIndex === 0) {
+            setPopperOpen(false);
+          }
+        }, 5000);
+        setTimeout(() => {
+          setPopperOpen(true);
+          setPopperContentIndex(0);
+        }, recommendedTime / 2 * 1000);
+        setTimeout(() => {
+          if (popperContentIndex === 0) {
+            setPopperOpen(false);
+          }
+        }, recommendedTime / 2 * 1000 + 5000);
+
         console.log(archiveData);
         setArchiveData(archiveData);
         setDBArchiveData(archiveData);


### PR DESCRIPTION
###Description
- Previously, pin time is stored as the time passed after the session page is loaded. It should instead be the time passed after the client clicks the "Start Recording" button, or else the pin time will be later than it should be. This PR solves the problem. 