### PR TITLE
useEffect edits to allow pin text rendering

### DIFF
--- a/src/components/DissResponse.js
+++ b/src/components/DissResponse.js
@@ -86,7 +86,7 @@ const DissResponse = ({ curPinIndex, setCurPinIndex, prevPinIndex, setPrevPinInd
             setCurOpportunityInfo(pins[curPinIndex].pinOpportunity);
             // eslint-disable-next-line react-hooks/exhaustive-deps
         }
-    }, [curPinIndex, curGoalInfo, curOpporunityInfo, curStrengthInfo, pins, prevPinIndex])//curPinIndex shouldn't change if there are not pins. 
+    }, [curPinIndex, pins, prevPinIndex])//curPinIndex shouldn't change if there are not pins. 
 
 
     // for updating and fetching current text field value

--- a/src/components/Notetaking.js
+++ b/src/components/Notetaking.js
@@ -177,22 +177,23 @@ const Notetaking = ({ curPinIndex, setCurPinIndex, prevPinIndex, setPrevPinIndex
         savePin(prevPinIndex);
 
         //clear out all the states
-        if (pins[curPinIndex] && user.userMode === "caller") {
-            setPinType(pins[curPinIndex].callerPinCategory);
-            setCurNoteInfo(pins[curPinIndex].callerPinNote);
-            setCurPerspectiveInfo(pins[curPinIndex].callerPinPerspective);
-            setCurSkillInfo(pins[curPinIndex].callerPinSkill);
-        } else if(pins[curPinIndex]){
-            setPinType(pins[curPinIndex].calleePinCategory);
-            setCurNoteInfo(pins[curPinIndex].calleePinNote);
-            setCurPerspectiveInfo(pins[curPinIndex].calleePinPerspective);
-            setCurSkillInfo(pins[curPinIndex].calleePinSkill);
+        const nextPin = pins[curPinIndex];
+        if (nextPin && user.userMode === "caller") {
+            setPinType(nextPin.callerPinCategory);
+            setCurNoteInfo(nextPin.callerPinNote);
+            setCurPerspectiveInfo(nextPin.callerPinPerspective);
+            setCurSkillInfo(nextPin.callerPinSkill);
+        } else if(nextPin){
+            setPinType(nextPin.calleePinCategory);
+            setCurNoteInfo(nextPin.calleePinNote);
+            setCurPerspectiveInfo(nextPin.calleePinPerspective);
+            setCurSkillInfo(nextPin.calleePinSkill);
         }
         //reset all the refs
         noteValueRef.current.value = curNoteInfo;
         perspectiveValueRef.current.value = curPerspectiveInfo;
         skillValueRef.current.value = curSkillInfo;
-    }, [curPinIndex, curNoteInfo, curPerspectiveInfo, curSkillInfo, pins, prevPinIndex, user.userMode])
+    }, [ prevPinIndex, curPinIndex])
 
    
 


### PR DESCRIPTION
Fixed useEffect in discussion prep and discussion sections to allow pin text to save and render correctly. More testing might be necessary to ensure it works in edge cases (like single or no pins).
