### PR TITLE
Linked individual responses in Discussion to DB

### DIFF
--- a/src/components/AudioReview.js
+++ b/src/components/AudioReview.js
@@ -87,9 +87,12 @@ const AudioReview = ({curPinIndex, setCurPinIndex, prevPinIndex, setPrevPinIndex
             calleePinPerspective: '',
             calleePinCategory: '',
             calleePinSkill: '',
-            pinGoal: '',
-            pinStrength: '',
-            pinOpportunity: '',
+            callerPinGoal: '',
+            callerPinStrength: '',
+            callerPinOpportunity: '',
+            calleePinGoal: '',
+            calleePinStrength: '',
+            calleePinOpportunity: '',
         }; 
 
         //now correctly add the pin into the array to maintain sortedness

--- a/src/components/DissResponse.js
+++ b/src/components/DissResponse.js
@@ -75,18 +75,59 @@ const DissResponse = ({ curPinIndex, setCurPinIndex, prevPinIndex, setPrevPinInd
     const [curStrengthInfo, setCurStrengthInfo] = useState(getCurrentPinInfo("pinStrength"));
     const [curOpporunityInfo, setCurOpportunityInfo] = useState(getCurrentPinInfo("pinOpportunity"));
 
+    const savePin = (index) => {
+        const lastPin = pins[index];
+        if(user.userMode === 'caller') {
+            lastPin.callerPinGoal = curGoalInfo;
+            lastPin.callerPinStrength = curStrengthInfo;
+            lastPin.callerPinOpportunity = curOpporunityInfo;
+        } else {
+            lastPin.calleePinGoal = curGoalInfo;
+            lastPin.calleePinStrength = curStrengthInfo;
+            lastPin.calleePinOpportunity = curOpporunityInfo;
+        }
+        pins[index] = lastPin;
+    }
+
     useEffect(() => {
         if (pins.length > 0){
             fetchCurTextVal();
-            pins[prevPinIndex].pinGoal = curGoalInfo;
-            pins[prevPinIndex].pinStrength = curStrengthInfo;
-            pins[prevPinIndex].pinOpportunity = curOpporunityInfo;
-            setCurGoalInfo(pins[curPinIndex].pinGoal);
-            setCurStrengthInfo(pins[curPinIndex].pinStrength);
-            setCurOpportunityInfo(pins[curPinIndex].pinOpportunity);
+    
+            setCurGoalInfo(goalValueRef.current.value);
+            setCurStrengthInfo(strengthValueRef.current.value);
+            setCurOpportunityInfo(opportunityValueRef.current.value);
+
+            console.log("prevPinIndex: " + prevPinIndex);
+            console.log("curPinIndex: " + curPinIndex);
+
+            const lastPin = pins[prevPinIndex];
+            if(lastPin) {
+                savePin(prevPinIndex);
+            }
+            const nextPin = pins[curPinIndex];
+            console.log(lastPin);
+            if(nextPin && user.userMode === 'caller') {  
+                setCurGoalInfo(nextPin.callerPinGoal);
+                setCurStrengthInfo(nextPin.callerPinStrength);
+                setCurOpportunityInfo(nextPin.callerPinOpportunity);
+            } else if (nextPin) {
+                setCurGoalInfo(nextPin.calleePinGoal);
+                setCurStrengthInfo(nextPin.calleePinStrength);
+                setCurOpportunityInfo(nextPin.calleePinOpportunity);
+            } else {
+                console.log("???")
+            }
             // eslint-disable-next-line react-hooks/exhaustive-deps
+            //reset all the refs
+            console.log("curGoalInfo: " + curGoalInfo);
+            console.log("curStrengthInfo: " + curStrengthInfo);
+            console.log("curOpportunityInfo: " + curOpporunityInfo);
+
+            goalValueRef.current.value = curGoalInfo;
+            strengthValueRef.current.value = curStrengthInfo;
+            opportunityValueRef.current.value = curOpporunityInfo;
         }
-    }, [curPinIndex, pins, prevPinIndex])//curPinIndex shouldn't change if there are not pins. 
+    }, [curPinIndex, prevPinIndex])//curPinIndex shouldn't change if there are not pins. 
 
 
     // for updating and fetching current text field value
@@ -106,6 +147,7 @@ const DissResponse = ({ curPinIndex, setCurPinIndex, prevPinIndex, setPrevPinInd
 
         setCurSkillInfo1(curPin.callerPinSkill);
         setCurSkillInfo2(curPin.calleePinSkill);
+
     }
 
     const handlePrevPin = () => {

--- a/src/components/VideoChatComponent.js
+++ b/src/components/VideoChatComponent.js
@@ -305,9 +305,12 @@ function VideoChatComponent(props) {
       calleePinPerspective: '',
       calleePinCategory: '',
       calleePinSkill: '',
-      pinGoal: '',
-      pinStrength: '',
-      pinOpportunity: '',
+      callerPinGoal: '',
+      callerPinStrength: '',
+      callerPinOpportunity: '',
+      calleePinGoal: '',
+      calleePinStrength: '',
+      calleePinOpportunity: '',
     };
 
     //Otherwise, use this code, as it will save reads and writes in the long run:
@@ -324,9 +327,12 @@ function VideoChatComponent(props) {
       calleePinPerspective: myPin.calleePinPerspective,
       calleePinCategory: myPin.calleePinCategory,
       calleePinSkill: myPin.calleePinSkill,
-      pinGoal: '',
-      pinStrength: '',
-      pinOpportunity: '',
+      callerPinGoal: '',
+      callerPinStrength: '',
+      callerPinOpportunity: '',
+      calleePinGoal: '',
+      calleePinStrength: '',
+      calleePinOpportunity: '',
     });
     myPin.pinID = docRef.id;
     //update with pinID

--- a/src/components/VideoDiscussionSecond.js
+++ b/src/components/VideoDiscussionSecond.js
@@ -196,10 +196,6 @@ function VideoChatComponentSecond(props) {
     console.log(curTime);  
   }
 
-  
-
-
-
   const renderToolbar = () => {
     return (
       <>
@@ -320,7 +316,32 @@ function VideoChatComponentSecond(props) {
     );
   };
 
+  const savePin = async (index) => {
+    const myPin = pins[index];
+    console.log(myPin);
+    if(user.userMode === "callee") {
+      await firebase.firestore().collection("sessions").doc(session.sessionID).collection("pins").doc(myPin.pinID).update({
+        calleePinGoal: myPin.calleePinGoal,
+        calleePinStrength: myPin.calleePinStrength,
+        calleePinOpportunity: myPin.calleePinOpportunity,
+      })
+      .then(() => {console.log("current pin successfully updated") })
+      .catch((e) => { console.log("pin update unsuccessful: " + e) });
+    } else {
+      await firebase.firestore().collection("sessions").doc(session.sessionID).collection("pins").doc(myPin.pinID).update({
+        callerPinGoal: myPin.callerPinGoal,
+        callerPinStrength: myPin.callerPinStrength,
+        callerPinOpportunity: myPin.callerPinOpportunity,
+      })
+      .then(() => {console.log("current pin successfully updated") })
+      .catch((e) => { console.log("pin update unsuccessful: " + e) });
+    }
+  }
+
   const handleStartChat = async (setApiKey, setSessionId, setToken, baseURL) => {
+    //save pins to db
+    pins.forEach((elem, id) => savePin(id));
+    //rest
     setOpen(false);
     console.log("loading info now...");
     setLoadingStatus(true);


### PR DESCRIPTION
Fixed bug with writing discussion responses for each pin to the db. For now, caller and callee responses are recorded individually in the db for the goals, strengths, and opportunities related to each pin.